### PR TITLE
Certificate must exactly match text

### DIFF
--- a/app/views/current/r1/601-4000-8-copy.html
+++ b/app/views/current/r1/601-4000-8-copy.html
@@ -1,0 +1,150 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <span class="govuk-caption-xl gem-c-title__context">
+       Early Years Qualification List
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        NCFE CACHE Level 3 Diploma in Early Years Education and Care (Early Years Educator)
+      </h1>
+
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "NCFE"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Level"
+            },
+            value: {
+              text: "Level 3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date added to Early Years Qualification List"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date of check"
+            },
+            value: {
+              text: "21 February 2024"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      <p>
+        This qualification is approved by the Department for Education (DfE) as full and relevant, subject to the following notes:
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Where the qualification certificate shows NCFE CACHE Level 3 Diploma in Early Years Education and Care (Knowledge only pathway) the holder cannot count in the ratios.</li>
+        </ul>
+      </p>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          You must make sure that the qualification name exactly matches the qualification on the certificate, including any wording in brackets.
+        </strong>
+      </div>
+
+      <p>
+        This is a level 3 qualification which was started after 1 September 2014. Someone who holds this qualification can be included in staff:child ratios at level 3, as long as they meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" class="govuk-link">early years foundation stage (EYFS)</a> statutory framework and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards" class="govuk-link">early years qualification requirements and standards</a> statutory guidance document.
+      </p>
+
+      <p>
+        If they do not meet all other requirements to be included in the level 3 staff:child ratios, they may be able to work in the level 2 ratios.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        Get more help and advice
+      </h2>
+
+      <p>
+          If you need more help, contact Ecctis. Ecctis provides qualification checking guidance on behalf of DfE. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on its website.
+      </p>
+
+
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="govuk-prototype-kit-common-templates-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Related content
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Check another qualification
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years foundation stage statutory framework (EYFS)
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualification requirements and standards
+              </a>
+            </li>
+            <!-- <li>
+              <a href="#" class="govuk-!-font-weight-bold">
+                More <span class="govuk-visually-hidden">in Subsection</span>
+              </a>
+            </li> -->
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/current/r1/start.html
+++ b/app/views/current/r1/start.html
@@ -45,6 +45,17 @@
         <li>confirm if someone who holds this qualification can count in staff:child ratios, as set out in the early years foundation stage (EYFS)</li>
       </ul>
 
+      <p>
+        You will need the certificate for the qualification you want to check.
+      </p>
+
+      <p>
+        You must make sure that the qualification you check exactly matches the qualification on the certificate, including any wording in brackets.
+      </p>
+      <p>
+        The qualification must exactly match the one on the early years qualifications list (EYQL) to be approved as full and relevant by the Department for Education.
+      </p>
+
       <!-- <p>Registering takes around 5 minutes.</p> -->
 
       {{ govukButton({
@@ -53,20 +64,7 @@
         isStartButton: true
       }) }}
 
-      <h2 class="govuk-heading-m">
-        Before you start
-      </h2>
 
-      <p>
-        For more information on qualification requirements, see the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards" class="govuk-link">Early years qualification requirements and standards</a> statutory guidance and the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" class="govuk-link">EYFS statutory framework</a>. Ensure that you refer to the correct version of the EYFS (group and school-based providers, or childminders).
-      </p>
-
-      <p>
-        For information on non-UK qualifications, refer to the <a href="https://www.gov.uk/government/publications/early-years-qualifications-achieved-outside-england" class="govuk-link">early years qualifications achieved outside the United Kingdom</a> guidance.
-      </p>
-      <p>
-        Ecctis provide a dedicated early years advisory service for further queries on Early Years qualifications. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on its website.
-      </p>
 
     </div>
 


### PR DESCRIPTION
Work in progress, but changed some text on a version of a results page to tell users that a certificate must exactly match.

Added similar text and instruction to have certificate to hand when checking to the start page