### PR TITLE
Fixture/eyqb 310 update prototype

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -63,4 +63,7 @@ router.use('/current/r8', require('./views/current/r8/_routes'));
 // r9
 router.use('/current/r9', require('./views/current/r9/_routes'));
 
+// r10
+router.use('/current/r10', require('./views/current/r10/_routes'));
+
 module.exports = router

--- a/app/views/current/r10/_routes.js
+++ b/app/views/current/r10/_routes.js
@@ -1,0 +1,104 @@
+const express = require('express')
+const router = express.Router()
+// Add your routes here - above the module.exports line
+
+var data = require('../../../data/qualifications.json');
+
+router.post('/set-awarding-orgs', function(request, response){
+  request.session.data['awarding-organisations'] = setAwardingOrganisations(data.qualifications, request);
+
+  response.redirect("/current/r10/q4");
+})
+
+// Route search results
+router.post('/post-search-results', function(request, response) {
+  var qualifications = data.qualifications;
+
+  if (request.session.data['qualification-search'] != undefined) {
+    var searchTerm = request.session.data['qualification-search'];
+    qualifications = data.qualifications.filter(x => x.name.toLowerCase().includes(searchTerm.toLowerCase()));
+  }
+
+  qualifications = filterQualificationYear(qualifications, request);
+  qualifications = filterLevels(qualifications, request);
+  qualifications = filterAwardingOrganisations(qualifications, request);
+  request.session.data['result-count'] = qualifications.length;
+  request.session.data['search-results'] = qualifications;
+  
+  const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  var date = new Date(Date.now());
+  var dateString = date.getDate() + nth(date.getDate()) + " " + months[date.getMonth()] + " " + date.getFullYear();
+  request.session.data['todays-date'] = dateString;
+
+  response.redirect("/current/r10/search-results");
+})
+
+const nth = (d) => {
+  const last = +String(d).slice(-2);
+  if (last > 3 && last < 21) return 'th';
+  const remainder = last % 10;
+  if (remainder === 1) return "st";
+  if (remainder === 2) return "nd";
+  if (remainder === 3) return "rd";
+  return "th";
+};
+
+function filterQualificationYear(qualifications, request) {
+  // if the data doesn't include the qualification year then just return the list of qualifications as nothing to filter out.
+  if (request.session.data['awarding-date'] == undefined || request.session.data['awarding-date'].length == 0) return qualifications;
+
+  return qualifications.filter(x => x.beforeOrAfter2014 == request.session.data['awarding-date']);
+}
+
+function filterLevels(qualifications, request) {
+  // reset level checked to false
+  for (var i = 2; i <= 8; i++) {
+    var levelChecked = `level-${i}-checked`;
+    request.session.data[levelChecked] = false;
+  }
+
+  // if the data doesn't include the qualification level then just return the list of qualifications as nothing to filter out.
+  if (request.session.data['qualification-level'] == undefined || request.session.data['qualification-level'].length == 0) return qualifications;
+
+  // User has selected qualification levels. Iterate through the selected levels and filter out the qualifications that match
+  var filteredLevelQualifications = [];
+  for (var i = 0; i < request.session.data['qualification-level'].length; i++) {
+    var level = request.session.data['qualification-level'][i];
+    var levelChecked = `level-${level}-checked`;
+    // Used to show the level is checked when the page reloads
+    request.session.data[levelChecked] = true;
+    var levelQualifications = qualifications.filter(x => x.level == level);
+    filteredLevelQualifications = filteredLevelQualifications.concat(levelQualifications);
+  }
+  return filteredLevelQualifications;
+}
+
+function filterAwardingOrganisations(qualifications, request) {
+  // if the data doesn't include the awarding organisation filter, then return the lot
+  if (request.session.data['awarding-organisation'] == undefined || request.session.data['awarding-organisation'] == 'none' || request.session.data['awarding-organisation'] == 'any') return qualifications;
+
+  return qualifications.filter(x => x.awardingOrganisation == request.session.data['awarding-organisation']);
+}
+
+function compareByText(a, b){
+  return a.text.localeCompare(b.text);
+}
+
+function setAwardingOrganisations(qualifications, request) {
+  var awardingOrganisations = qualifications.map(x => x.awardingOrganisation);
+  let uniqueAwardingOrganisations = [...new Set(awardingOrganisations)];
+  var formattedAwardingOrganisations = [];
+  uniqueAwardingOrganisations.forEach(element => {
+    if (request.session.data['awarding-organisation'] != undefined && element == request.session.data['awarding-organisation']) {
+      formattedAwardingOrganisations.push({"value": element, "text": element, "selected": true});
+    } else {
+      formattedAwardingOrganisations.push({"value": element, "text": element});
+    }
+  });
+  formattedAwardingOrganisations = formattedAwardingOrganisations.sort(compareByText);
+  formattedAwardingOrganisations.unshift({"value": "any", text: "Not in the list"});
+  formattedAwardingOrganisations.unshift({"value": "none", text: "Choose the awarding organisation"});
+  return formattedAwardingOrganisations;
+}
+
+module.exports = router

--- a/app/views/current/r10/_routes.js
+++ b/app/views/current/r10/_routes.js
@@ -7,7 +7,7 @@ var data = require('../../../data/qualifications.json');
 router.get('/reset-filters', function(request, response) {
   var resetData = {};
   // reset level checked to false
-  for (var i = 2; i <= 7; i++) {
+  for (var i = 2; i <= 8; i++) {
     var levelChecked = `level-${i}-checked`;
     resetData[levelChecked] = false;
   }
@@ -63,14 +63,15 @@ function filterQualificationYear(qualifications, request) {
   // if the data doesn't include the qualification year then just return the list of qualifications as nothing to filter out.
   if (request.session.data['date-started-month'] == undefined || request.session.data['date-started-year'] == undefined || request.session.data['date-started-month'].length == 0 || request.session.data['date-started-year'].length == 0) return qualifications;
   
-  var filterValue = 'before'; // Current options in the beforeOrAfter2014 field is before, after & 2024
+  var filterValue = ''; // Current options in the beforeOrAfter2014 field is before, after & 2024
   var monthAsInt = request.session.data['date-started-month'];
   var yearAsInt = request.session.data['date-started-year'];
-  if (monthAsInt >= 9 && (yearAsInt >= 2014 && yearAsInt < 2024)){
+  if (monthAsInt < 9 && yearAsInt <= 2014){
+    filterValue = 'before';
+  } else if (monthAsInt >= 9 && yearAsInt == 2014 || monthAsInt >= 1 && yearAsInt > 2014 && monthAsInt < 9 && yearAsInt <= 2024){
     filterValue = 'after';
-  }
-  if (monthAsInt >= 9 && yearAsInt >= 2024){
-    filterValue = '2024';
+  } else {
+    filterValue = '2024'
   }
 
   request.session.data['awarding-date'] = filterValue;

--- a/app/views/current/r10/eyq-223-checked.html
+++ b/app/views/current/r10/eyq-223-checked.html
@@ -1,0 +1,270 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">
+        Your result
+      </h1>
+
+        {{ govukSummaryList({
+          rows: [
+
+                {
+              key: {
+                text: "Qualification"
+              },
+              value: {
+                text: "NCFE CACHE Level 3 Diploma in Early Years Education and Care (Early Years Educator)"
+              }
+            },
+
+          {
+              key: {
+                text: "Qualification level"
+              },
+              value: {
+                text: "3"
+              },
+              actions: {
+
+              }
+            }
+            ,
+            {
+                key: {
+                  text: "Awarding organisation"
+                },
+                value: {
+                  text: "NCFE CACHE"
+                },
+                actions: {
+
+                }
+              }
+              ,
+            {
+                key: {
+                  text: "Date added to early years qualifications list"
+                },
+                value: {
+                  text: "1 September 2014"
+                },
+                actions: {
+
+                }
+              }
+              ,
+            {
+              key: {
+                text: "Date checked"
+              },
+              value: {
+                text: data['todays-date']
+              },
+              actions: {
+
+              }
+            }
+          ]
+        }) }}
+
+
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p class="govuk-body-l"><strong>Your answers</strong></p>
+
+
+
+      <div style="margin-top:40px;" class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="max-width:35em; margin-bottom:20px;" class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <p style="padding-left:900px; margin-top:-60px;" class=class="govuk-body-m">
+      Yes
+    </p>
+  </fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Does the qualification name include Early Years Educator?
+</p>
+</legend>
+  <p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+    Yes
+  </p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+            <p class="govuk-body">
+        <a href="eyq-224" class="govuk-link">Change my answers</a>
+      </p>
+
+      <br>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided.
+        </strong>
+      </div>
+
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+
+
+                  <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Unqualified</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to work as an unqualified member of staff
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
+
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Level 2</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to count in the level 2 staff to child ratios
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+              Level 3</strong>
+            </p>
+          </legend>
+          <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+            Approved
+          </p>
+          <details class="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Other requirements to count in the level 3 staff to child ratios
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+              <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
+              <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+            </ul>
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+              </p>
+            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+          </div>
+        </details>
+        </fieldset>
+      </div>
+      <hr>
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+       Level 6</strong>
+      </p>
+    </legend>
+    <p style="margin-left:850px; margin-top:-60px; background-color:red; color: white;" class="govuk-tag govuk-tag--green">
+    Not approved
+    </p>
+    <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Requirements to work at level 6
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Qualified Teacher Status</li>
+        <li>Early Years Teacher Status</li>
+        <li>Early Years Professional Status (EYPS)</li>
+      </ul>
+      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+    </div>
+  </details>
+  </fieldset>
+</div>
+<hr>
+
+<br>
+<button onclick="window.print();" class="govuk-link govuk-body-s gem-c-print-link__button">Print this page</button>
+
+<br><br>
+<p class="govuk-body">
+<a href="q1" class="govuk-link">Check another qualification</a>
+</p>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-223-checked.html
+++ b/app/views/current/r10/eyq-223-checked.html
@@ -260,7 +260,7 @@
 
 <br><br>
 <p class="govuk-body">
-<a href="q1" class="govuk-link">Check another qualification</a>
+<a href="/current/r10/reset-filters" class="govuk-link">Check another qualification</a>
 </p>
 
     </div>

--- a/app/views/current/r10/eyq-223.html
+++ b/app/views/current/r10/eyq-223.html
@@ -1,0 +1,173 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <!-- <span class="govuk-caption-xl gem-c-title__context">
+       Early years qualifications list
+      </span> -->
+
+      <h1 class="govuk-heading-xl">
+        Check the additional requirements
+      </h1>
+
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "NCFE CACHE Level 3 Diploma in Early Years Education and Care (Early Years Educator)"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "NCFE CACHE"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+
+            <div style="margin-top:50px;" class="govuk-inset-text">
+        You can bookmark this page if you need to return to it later
+      </div>
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p style="margin-top:25px;" class="govuk-body-l"><strong>Please answer the following questions</strong></p>
+
+
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="max-width:35em; margin-bottom:20px; margin-top:20px;" class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <div style="padding-left:740px; margin-top:-70px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014" name="sep2014" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="sep2014">
+          Yes
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014-2" name="sep2014" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="sep2014-2">
+          No
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-bottom:20px; margin-top:20px;" class="govuk-body-m">
+  Does the qualification name include Early Years Educator?
+</p>
+</legend>
+<div style="padding-left:740px; margin-top:-70px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears" name="earlyyears" type="radio" value="yes">
+  <label class="govuk-label govuk-radios__label" for="earlyyears">
+    Yes
+  </label>
+</div>
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears-2" name="earlyyears" type="radio" value="no">
+  <label class="govuk-label govuk-radios__label" for="earlyyears-2">
+    No
+  </label>
+</div>
+</div>
+</fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+        </strong>
+      </div>
+
+      <form class="form" action="/current/r10/eyq-223-checked" method="post">
+            {{ govukButton({
+        text: "Get result"
+      }) }}
+      </form>
+
+
+
+
+
+
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-224-checked.html
+++ b/app/views/current/r10/eyq-224-checked.html
@@ -263,7 +263,7 @@
 
 <br><br>
 <p class="govuk-body">
-<a href="q1" class="govuk-link">Check another qualification</a>
+  <a href="/reset-filters" class="govuk-link">Check another qualification</a>
 </p>
 
     </div>

--- a/app/views/current/r10/eyq-224-checked.html
+++ b/app/views/current/r10/eyq-224-checked.html
@@ -1,0 +1,273 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">
+        Your result
+      </h1>
+
+
+        {{ govukSummaryList({
+          rows: [
+
+                {
+              key: {
+                text: "Qualification"
+              },
+              value: {
+                text: "NCFE CACHE Level 3 Diploma for the Early Years Workforce (Early Years Educator)"
+              }
+            },
+
+          {
+              key: {
+                text: "Qualification level"
+              },
+              value: {
+                text: "3"
+              },
+              actions: {
+
+              }
+            }
+            ,
+            {
+                key: {
+                  text: "Awarding organisation"
+                },
+                value: {
+                  text: "NCFE CACHE"
+                },
+                actions: {
+
+                }
+              }
+              ,
+            {
+                key: {
+                  text: "Date added to early years qualifications list"
+                },
+                value: {
+                  text: "1 September 2014"
+                },
+                actions: {
+
+                }
+              }
+              ,
+            {
+              key: {
+                text: "Date checked"
+              },
+              value: {
+                text: data['todays-date']
+              },
+              actions: {
+
+              }
+            }
+          ]
+        }) }}
+
+
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p class="govuk-body-l"><strong>Your answers</strong></p>
+
+
+
+      <div style="margin-top:40px;" class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="max-width:35em; margin-bottom:20px;" class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <p style="padding-left:900px; margin-top:-60px;" class=class="govuk-body-m">
+      Yes
+    </p>
+  </fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Does the qualification name include Early Years Educator?
+</p>
+</legend>
+  <p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+    Yes
+  </p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+
+            <p class="govuk-body">
+        <a href="eyq-224" class="govuk-link">Change my answers</a>
+      </p>
+
+      <br>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided.
+        </strong>
+      </div>
+
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+
+
+                  <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Unqualified</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to work as an unqualified member of staff
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
+
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Level 2</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to count in the level 2 staff to child ratios
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+              Level 3</strong>
+            </p>
+          </legend>
+          <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+            Approved
+          </p>
+          <details class="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Other requirements to count in the level 3 staff to child ratios
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+              <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
+              <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+            </ul>
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+              </p>
+            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+          </div>
+        </details>
+        </fieldset>
+      </div>
+      <hr>
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+       Level 6</strong>
+      </p>
+    </legend>
+    <p style="margin-left:850px; margin-top:-60px; background-color:red; color: white;" class="govuk-tag govuk-tag--green">
+    Not approved
+    </p>
+    <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Requirements to work at level 6
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Qualified Teacher Status</li>
+        <li>Early Years Teacher Status</li>
+        <li>Early Years Professional Status (EYPS)</li>
+      </ul>
+      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+    </div>
+  </details>
+  </fieldset>
+</div>
+<hr>
+
+<br>
+<button onclick="window.print();" class="govuk-link govuk-body-s gem-c-print-link__button">Print this page</button>
+
+<br><br>
+<p class="govuk-body">
+<a href="q1" class="govuk-link">Check another qualification</a>
+</p>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-224.html
+++ b/app/views/current/r10/eyq-224.html
@@ -1,0 +1,163 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">
+        Check the additional requirements
+      </h1>
+
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "NCFE CACHE Level 3 Diploma for the Early Years Workforce (Early Years Educator)"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "NCFE CACHE"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+
+            <div style="margin-top:50px;" class="govuk-inset-text">
+        You can bookmark this page if you need to return to it later
+      </div>
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p style="margin-top:25px;" class="govuk-body-l"><strong>Please answer the following questions</strong></p>
+
+
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="max-width:35em; margin-bottom:20px; margin-top:20px;" class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <div style="padding-left:740px; margin-top:-70px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014" name="sep2014" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="sep2014">
+          Yes
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014-2" name="sep2014" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="sep2014-2">
+          No
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-bottom:20px; margin-top:20px;" class="govuk-body-m">
+  Does the qualification name include Early Years Educator?
+</p>
+</legend>
+<div style="padding-left:740px; margin-top:-70px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears" name="earlyyears" type="radio" value="yes">
+  <label class="govuk-label govuk-radios__label" for="earlyyears">
+    Yes
+  </label>
+</div>
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears-2" name="earlyyears" type="radio" value="no">
+  <label class="govuk-label govuk-radios__label" for="earlyyears-2">
+    No
+  </label>
+</div>
+</div>
+</fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+        </strong>
+      </div>
+
+      <form class="form" action="/current/r10/eyq-224-checked" method="post">
+            {{ govukButton({
+        text: "Get result"
+      }) }}
+      </form>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-300-checked.html
+++ b/app/views/current/r10/eyq-300-checked.html
@@ -268,7 +268,7 @@
 
 <br><br>
 <p class="govuk-body">
-<a href="q1" class="govuk-link">Check another qualification</a>
+<a href="/reset-filters" class="govuk-link">Check another qualification</a>
 </p>
 
     </div>

--- a/app/views/current/r10/eyq-300-checked.html
+++ b/app/views/current/r10/eyq-300-checked.html
@@ -1,0 +1,278 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">
+        Your result
+      </h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+              {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "BA (Hons) in Early Childhood Studies"
+            }
+          },
+
+        {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+              key: {
+                text: "Awarding organisation"
+              },
+              value: {
+                text: "University of Buxton"
+              },
+              actions: {
+
+              }
+            }
+            ,
+          {
+              key: {
+                text: "Date added to early years qualifications list"
+              },
+              value: {
+                text: "1 September 2014"
+              },
+              actions: {
+
+              }
+            }
+            ,
+          {
+            key: {
+              text: "Date checked"
+            },
+            value: {
+              text: data['todays-date']
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+      <p class="govuk-body-l"><strong>Your answers</strong></p>
+      <div style="margin-top:40px;" class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="max-width:35em; margin-bottom:20px;" class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <p style="padding-left:900px; margin-top:-60px;" class=class="govuk-body-m">
+      Yes
+    </p>
+  </fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Did the qualification include an <a href="">element of assessed practice in an early years setting</a>?
+</p>
+</legend>
+  <p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+    Yes
+  </p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Was the course fully consistent with the <a href="">QAA subject benchmark statement for Early Childhood Studies</a>?
+</p>
+</legend>
+<p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+  Yes
+</p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+            <p class="govuk-body">
+        <a href="eyq-300" class="govuk-link">Change my answers</a>
+      </p>
+
+      <br>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided.
+        </strong>
+      </div>
+
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+
+
+                  <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Unqualified</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to work as an unqualified member of staff
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
+
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Level 2</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to count in the level 2 staff to child ratios
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+              Level 3</strong>
+            </p>
+          </legend>
+          <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+            Approved
+          </p>
+          <details class="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Other requirements to count in the level 3 staff to child ratios
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+              <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
+              <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+            </ul>
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+              </p>
+            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+          </div>
+        </details>
+        </fieldset>
+      </div>
+      <hr>
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+       Level 6</strong>
+      </p>
+    </legend>
+    <p style="margin-left:850px; margin-top:-60px; background-color:red; color: white;" class="govuk-tag govuk-tag--green">
+    Not approved
+    </p>
+    <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Requirements to work at level 6
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Qualified Teacher Status</li>
+        <li>Early Years Teacher Status</li>
+        <li>Early Years Professional Status (EYPS)</li>
+      </ul>
+      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+    </div>
+  </details>
+  </fieldset>
+</div>
+<hr>
+
+<br>
+<button onclick="window.print();" class="govuk-link govuk-body-s gem-c-print-link__button">Print this page</button>
+
+<br><br>
+<p class="govuk-body">
+<a href="q1" class="govuk-link">Check another qualification</a>
+</p>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-300-v1.html
+++ b/app/views/current/r10/eyq-300-v1.html
@@ -1,0 +1,189 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <span class="govuk-caption-xl gem-c-title__context">
+       Early years qualifications list
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        BA (Hons) Early Childhood Studies
+      </h1>
+
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "University of Buxton"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Level"
+            },
+            value: {
+              text: "Level 6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date of check"
+            },
+            value: {
+              text: "19 March 2024"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      <p>
+        This qualification is approved by the Department for Education (DfE) as full and relevant, subject to the following additional requirements:
+      </p>
+
+      <p>
+        Training providers should be able to provide clarification on the below criteria:
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>The course must be fully consistent with the <a href="#">QAA subject benchmark statement for Early Childhood Studies</a></li>
+          <li>The qualification must include an <a href="#">element of assessed practice in an early years setting</a>.</li>
+        </ul>
+      </p>
+
+      <div class="govuk-inset-text">
+          You must make sure that the qualification name exactly matches the qualification on the certificate, including any wording in brackets.
+      </div>
+
+      <p>
+        This is a level 6 qualification which was started after 1 September 2014. Someone who holds this qualification can be included in staff to child ratios at level 3 as long as they meet all the other level 3 requirements.</p>
+
+      <h2 class="govuk-heading-m">
+        Other requirements to work in the staff to child ratios at level 3
+      </h2>
+
+      <p>
+        For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>hold a suitable level 2 English qualification, as specified in the <a href="#">early years qualification requirements and standards document</a></li>
+        <li>hold a current paediatric first aid qualification which meets the criteria in the <a href="#">early years foundation stage (EYFS) statutory framework</a></li>
+        <li>meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" class="govuk-link">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards" class="govuk-link">early years qualification requirements and standards document</a></li>
+      </ul>
+
+      <p>
+        A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+      </p>
+
+      <h2 class="govuk-heading-m">
+      Requirements to work in the staff to child ratios at level 6
+      </h2>
+
+      <p>
+        To be included in the staff to child ratios at level 6, staff must hold one of the following or another approved level 6 qualification:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Qualified Teacher Status (QTS)</li>
+        <li>Early Years Teacher Status (EYTS)</li>
+        <li>Early Years Professional Status (EYPS)</li>
+      </ul>
+
+
+      <h2 class="govuk-heading-m">
+        Get more help and advice
+      </h2>
+
+      <p>
+          If you need more help, contact Ecctis Early Years Service. Ecctis provides qualification checking guidance on behalf of DfE. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on their website.
+      </p>
+
+
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="govuk-prototype-kit-common-templates-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Related content
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Check another qualification
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years foundation stage statutory framework (EYFS)
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualification requirements and standards
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Pathway into early years education
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications achieved outside the United Kingdom
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications that do not meet the criteria
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/current/r10/eyq-300.html
+++ b/app/views/current/r10/eyq-300.html
@@ -1,0 +1,189 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+
+      <h1 class="govuk-heading-xl">
+        Check the additional requirements
+      </h1>
+
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "BA (Hons) in Early Childhood Studies"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "University of Buxton"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+
+            <div style="margin-top:50px;" class="govuk-inset-text">
+        You can bookmark this page if you need to return to it later
+      </div>
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p style="margin-top:25px;" class="govuk-body-l"><strong>Please answer the following questions</strong></p>
+
+
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <div style="padding-left:740px; margin-top:-70px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014" name="sep2014" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="sep2014">
+          Yes
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014-2" name="sep2014" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="sep2014-2">
+          No
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<hr>
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em;" class="govuk-body-m">
+  Did the qualification include an <a href="">element of assessed practice in an early years setting</a>?
+</p>
+</legend>
+<div style="padding-left:740px; margin-top:-80px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears" name="earlyyears" type="radio" value="yes">
+  <label class="govuk-label govuk-radios__label" for="earlyyears">
+    Yes
+  </label>
+</div>
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears-2" name="earlyyears" type="radio" value="no">
+  <label class="govuk-label govuk-radios__label" for="earlyyears-2">
+    No
+  </label>
+</div>
+</div>
+</fieldset>
+</div>
+<hr>
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em;" class="govuk-body-m">
+  Was the course fully consistent with the <a href="">QAA subject benchmark statement for Early Childhood Studies</a>?
+</p>
+</legend>
+<div style="padding-left:740px; margin-top:-80px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="QAA" name="QAA" type="radio" value="yes">
+  <label class="govuk-label govuk-radios__label" for="QAA">
+    Yes
+  </label>
+</div>
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="QAA-2" name="QAA" type="radio" value="no">
+  <label class="govuk-label govuk-radios__label" for="QAA-2">
+    No
+  </label>
+</div>
+</div>
+</fieldset>
+</div>
+<hr>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+        </strong>
+      </div>
+
+      <form class="form" action="/current/r10/eyq-300-checked" method="post">
+            {{ govukButton({
+        text: "Get result"
+      }) }}
+      </form>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-301-v1.html
+++ b/app/views/current/r10/eyq-301-v1.html
@@ -1,0 +1,158 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <span class="govuk-caption-xl gem-c-title__context">
+       Early years qualifications list
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        Diploma for the Children and Young People's Workforce (Early Learning and Childcare)
+      </h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "CACHE"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Level"
+            },
+            value: {
+              text: "Level 3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "Before 1 September 2014"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date of check"
+            },
+            value: {
+              text: "19 March 2024"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      <p>
+        This qualification is approved by the Department for Education (DfE) as full and relevant.
+
+      <div class="govuk-inset-text">
+        You must make sure that the qualification name exactly matches the qualification on the certificate, including any wording in brackets.
+      </div>
+
+      <p>
+        This is a level 3 qualification which was started before 1 September 2014. Someone who holds this qualification can be included in staff to child ratios at level 3 as long as they meet all the other level 3 requirements.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        Other requirements to work in the staff to child ratios at level 3
+      </h2>
+
+      <p>
+        For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>hold a current paediatric first aid qualification which meets the criteria in the <a href="#">early years foundation stage (EYFS) statutory framework</a></li>
+        <li>meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" class="govuk-link">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards" class="govuk-link">early years qualification requirements and standards document</a></li>
+      </ul>
+
+      <h2 class="govuk-heading-m">
+        Get more help and advice
+      </h2>
+
+      <p>
+        If you need more help, contact Ecctis Early Years Service. Ecctis provides qualification checking guidance on behalf of DfE. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on their website.
+      </p>
+
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="govuk-prototype-kit-common-templates-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Related content
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Check another qualification
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years foundation stage statutory framework (EYFS)
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualification requirements and standards
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Pathway into early years education
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications achieved outside the United Kingdom
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications that do not meet the criteria
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/current/r10/index.html
+++ b/app/views/current/r10/index.html
@@ -1,0 +1,249 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Guidance - Check Early Years qualifications - GOV.UK
+{% endblock %}
+
+{% block header %}
+  <!-- Blank header with no service name for this page -->
+  {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "#"
+      },
+      {
+        text: "Education, training and skills",
+        href: "#"
+      }
+    ]
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+
+      <span class="govuk-caption-xl gem-c-title__context">
+        Guidance
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        Check early years qualifications
+      </h1>
+
+      <aside class="govuk-prototype-kit-common-templates-mainstream-guide-contents-list" role="complementary">
+        <nav class="govuk-prototype-kit-common-templates-contents-list" aria-label="Pages in this guide" role="navigation">
+          <h2 class="govuk-prototype-kit-common-templates-contents-list__title">
+            Contents
+          </h2>
+          <ol class="govuk-prototype-kit-common-templates-contents-list__list">
+            <li class="govuk-prototype-kit-common-templates-contents-list__list-item govuk-prototype-kit-common-templates-contents-list__list-item--dashed govuk-prototype-kit-common-templates-contents-list__list-item--active">
+              <a href="#qualification-requirements">Qualification requirements</a>
+            </li>
+            <li class="govuk-prototype-kit-common-templates-contents-list__list-item govuk-prototype-kit-common-templates-contents-list__list-item--dashed govuk-prototype-kit-common-templates-contents-list__list-item--active">
+              <a href="#qualifications-achieved-in-the-united-kingdom">Qualifications achieved in the United Kingdom</a>
+            </li>
+            <li class="govuk-prototype-kit-common-templates-contents-list__list-item govuk-prototype-kit-common-templates-contents-list__list-item--dashed govuk-prototype-kit-common-templates-contents-list__list-item--active">
+              <a href="#qualifications-achieved-outside-the-united-kingdom">Qualifications achieved outside the United Kingdom</a>
+            </li>
+            <li class="govuk-prototype-kit-common-templates-contents-list__list-item govuk-prototype-kit-common-templates-contents-list__list-item--dashed govuk-prototype-kit-common-templates-contents-list__list-item--active">
+              <a href="#qualifications-that-do-not-meet-the-criteria">Qualifications that do not meet the criteria</a>
+            </li>
+            <li class="govuk-prototype-kit-common-templates-contents-list__list-item govuk-prototype-kit-common-templates-contents-list__list-item--dashed govuk-prototype-kit-common-templates-contents-list__list-item--active">
+              <a href="#pathway-into-early-years">Pathway into early years</a>
+            </li>
+          </ol>
+        </nav>
+      </aside>
+
+    </div>
+
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-prototype-kit-common-templates-mainstream-guide-body">
+<!--       
+      <h2 class="govuk-heading-m">
+        Page content heading
+      </h2>
+
+      <dl class="govuk-list">
+        <dt class="gem-c-metadata__term">From:</dt>
+        <dd class="gem-c-metadata__definition">
+            <a class="govuk-link" href="/government/organisations/department-for-education">Department for Education</a>
+  
+        </dd>
+        <dt class="gem-c-metadata__term">Published</dt>
+        <dd class="gem-c-metadata__definition">25 April 2014</dd>
+        <dt class="gem-c-metadata__term">Last updated</dt>
+        <dd class="gem-c-metadata__definition">
+          5 September 2022
+            — <a href="#full-publication-update-history" class="gem-c-metadata__definition-link govuk-!-display-none-print js-see-all-updates-link" data-track-category="content-history" data-track-action="see-all-updates-link-clicked" data-track-label="history" data-module="ga4-link-tracker" data-ga4-link='{"event_name":"navigation","type":"content history","section":"Top","action":"opened"}'>
+              See all updates
+            </a>
+        </dd>
+    </dl> -->
+      
+      <p class="govuk-body-l">Find out if a person's qualifications allow them to work in an early years setting, and if you can include them in staff:child ratios.</p>
+
+      <p>Use the <a href="start.html">Check an Early Years qualification</a> service to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>check if a person's qualification meets the approved ‘full and relevant’ criteria for early years qualifications</li>
+        <li>confirm if a person counts in the <abbr title="early years foundation stage">EYFS</abbr> staff:child ratios</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">About this guidance</h2>
+
+      <p>This guidance is for anyone who wants information about early years qualifications.</p>
+
+      <p>All early years providers working with children from birth to 5 years old must follow the regulations on early years foundation stage (<abbr title="early years foundation stage">EYFS</abbr>) staff:child ratios. This is the number of qualified staff, at different qualification levels, an early years setting needs to have in order to meet the needs of all children and ensure their safety. These regulations are set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" class="govuk-link">early years foundation stage (<abbr title="early years foundation stage">EYFS</abbr>) statutory framework</a>.</p>
+
+      <p>Providers must make sure staff have the appropriate qualifications to count in the ratios, including the need to have at least one staff member trained in <a href="https://www.gov.uk/government/publications/early-years-qualifications-and-ratios/early-years-qualifications-and-ratios#paediatric" class="govuk-link">paediatric first aid</a>.</p>
+
+      <h2 class="govuk-heading-m" id="qualification-requirements">Qualification requirements</h2>
+
+      <h3 class="govuk-heading-s" id="qualifications-and-ratios">Qualifications and ratios</h3>
+
+      <p>The Department for Education (<abbr title="Department for Education">DfE</abbr>) defines the qualifications that staff must hold to count in <abbr title="early years foundation stage">EYFS</abbr> staff:child ratios. Providers can use our <a href="https://www.gov.uk/government/publications/early-years-qualifications-achieved-in-england" class="govuk-link">early years qualifications lists</a> to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>check if a person’s qualification meets the approved ‘full and relevant’ criteria for early years qualifications</li>
+        <li>confirm if a person counts in the <abbr title="early years foundation stage">EYFS</abbr> staff:child ratios</li>
+      </ul>
+
+      <p>The guidance on <a href="https://www.gov.uk/government/publications/early-years-qualifications-and-ratios" class="govuk-link">Early years qualifications and ratios</a> covers:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>which qualifications are acceptable to work in early years</li>
+        <li>paediatric first aid (<abbr title="paediatric first aid">PFA</abbr>)</li>
+        <li>how to contact the department and disputes</li>
+      </ul>
+
+      <h2 class="govuk-heading-m" id="qualifications-achieved-in-the-united-kingdom">Qualifications achieved in the United Kingdom</h2>
+
+      <p>The <a href="https://www.gov.uk/government/publications/early-years-qualifications-achieved-in-england" class="govuk-link">Early years qualifications achieved in the United Kingdom</a> guidance details the list of qualifications gained in the United Kingdom that are all full and relevant and accepted by <abbr title="Department for Education">DfE</abbr> to work in an early years setting.</p>
+
+      <p>It covers:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>qualifications started before 1 September 2014</li>
+        <li>qualifications started after 1 September 2014</li>
+        <li>level 2 and 3 qualifications</li>
+        <li>special educational needs and disability (<abbr title="special educational needs and disability">SEND</abbr>)</li>
+        <li>qualifications achieved in Scotland, Wales and Northern Ireland</li>
+      </ul>
+
+      <h2 class="govuk-heading-m" id="qualifications-achieved-outside-the-united-kingdom">Qualifications achieved outside the United Kingdom</h2>
+
+      <p>If you did not get your qualification in the United Kingdom you will have to make an application for recognition to work in early years education in England.</p>
+
+      <p><a href="https://www.gov.uk/government/publications/early-years-qualifications-achieved-outside-england" class="govuk-link">The Early years qualifications achieved outside the United Kingdom</a> guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the <abbr title="early years foundation stage">EYFS</abbr> staff:child ratios in England.</p>
+
+      <p>This applies to those in:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Europe</li>
+        <li>Rest of the world</li>
+      </ul>
+
+      <h2 class="govuk-heading-m" id="qualifications-that-do-not-meet-the-criteria">Qualifications that do not meet the criteria</h2>
+
+      <p>Some qualifications do not meet the ‘full and relevant’ criteria set by <abbr title="Department for Education">DfE</abbr>, meaning you cannot count them, at the appropriate level, in the <abbr title="early years foundation stage">EYFS</abbr> staff:child ratios.</p>
+
+      <p>Based on certain criteria this could include:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>nurses</li>
+        <li>midwives</li>
+        <li>specialist community public health nurses</li>
+      </ul>
+
+      <p>The <a href="https://www.gov.uk/government/publications/early-years-qualifications-that-do-not-meet-the-criteria" class="govuk-link">Early years qualifications that do not meet the criteria</a> guidance provides further information.</p>
+
+      <h2 class="govuk-heading-m" id="pathway-into-early-years">Pathway into early years</h2>
+
+      <p>The <a href="https://www.gov.uk/government/publications/pathway-into-early-years-education" class="govuk-link">Pathway into early years education</a> guidance is for:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>anyone considering a career in the sector</li>
+        <li>careers advisers</li>
+        <li>Department for Work and Pensions work coaches</li>
+        <li>early years practitioners who wish to progress their careers</li>
+        <li>employers</li>
+      </ul>
+
+      <p>It contains planning information and tools for those interested in working in the early years education sector including an <a href="https://www.gov.uk/government/publications/pathway-into-early-years-education/pathway-into-early-years-education/" class="govuk-link">Early years career progression map</a>.</p>
+
+
+
+      <nav class="govuk-prototype-kit-common-templates-pagination" role="navigation" aria-label="Pagination">
+
+      {{ govukPagination({
+        previous: {
+          labelText: "Page 1 title",
+          href: "#"
+        },
+        next: {
+          labelText: "Page 3 title",
+          href: "#"
+        }
+      }) }}
+
+      <p>
+        <a href="#">
+          View a printable version of the whole guide
+        </a>
+      </p>
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="govuk-prototype-kit-common-templates-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Related content
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Early years qualifications: pre-September 2014 criteria
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications and ratios
+              </a>
+            </li>
+            <!-- <li>
+              <a href="#" class="govuk-!-font-weight-bold">
+                More <span class="govuk-visually-hidden">in Subsection</span>
+              </a>
+            </li> -->
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+
+  </main>
+</div>
+
+
+
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/current/r10/not-listed.html
+++ b/app/views/current/r10/not-listed.html
@@ -1,0 +1,139 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <span class="govuk-caption-xl gem-c-title__context">
+       Early Years Qualification List
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        Anytown Level 3 Early Years Diploma
+      </h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "Anytown College"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Level"
+            },
+            value: {
+              text: "Level 3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date started"
+            },
+            value: {
+              text: "After 1 September 2023"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date of check"
+            },
+            value: {
+              text: "21 February 2024"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      <p>
+        This qualification is not listed on the Early Years Qualifications List (EYQL). It is therefore not approved as full and relevant by the Department for Education.
+      </p>
+
+      <p>
+        Only individuals who hold a full and relevant qualification listed on the EYQL can be counted towards staff:child ratios as qualified members of staff. However, they can work as an unqualified member of staff in the setting.
+
+      <p>
+        If the candidate holds a level 3, 4, 5, 6, 7 or 8 qualification that is not on the EYQL, they may be able to count in the early years foundation stage (EYFS) staff:child ratios at level 2, providing that:
+      </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the qualification was registered for or started between 1 September 2014 and 31 August 2019  </li>
+          <li>the qualification covers childcare and child development for the 0 to 5 age range </li>
+        </ul>
+
+      <h2 class="govuk-heading-m">
+        Bookmark a link to this qualification check
+      </h2>
+
+      <p>
+        A permanent link to this qualification check is available at:
+        <br />
+        <br />
+        <a href="#">https://check-early-years-qualification.service.gov.uk/qualification-check/601-3117-2</a>
+      </p>
+
+      <form action="#" method="post" novalidate>
+
+        {{ govukButton({
+          text: "Bookmark this qualification check",
+          classes: "govuk-button--secondary"
+        }) }}
+
+      </form>
+
+      <h2 class="govuk-heading-m">
+        Check another qualification
+      </h2>
+      <p>Return to the start of the <a href="start.html">Check an early years qualification</a> service to check another qualification.</p>
+
+      <h2 class="govuk-heading-m">
+        Further information about the Early Years Qualification List
+      </h2>
+
+      <p>For information on non-UK qualifications, refer to the <a href="https://www.gov.uk/government/publications/early-years-qualifications-achieved-outside-england" class="govuk-link">early years qualifications achieved outside the United Kingdom</a> guidance.</p>
+
+      <div class="govuk-inset-text">
+        <p>
+          If you have further queries, contact Ecctis. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on its website.
+        </p>
+
+        <p>
+          If you contacted the DfE early years workforce team prior to 5 September 2022, you do not need to contact Ecctis.
+        </p>
+      </div>
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/current/r10/not-on-list.html
+++ b/app/views/current/r10/not-on-list.html
@@ -1,0 +1,201 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <span class="govuk-caption-xl gem-c-title__context">
+       Early years qualifications list
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        The qualification I am looking for is not on the list
+      </h1>
+
+      <div class="govuk-inset-text">
+        If a qualification is not on the early years qualifications list (EYQL), it cannot be considered approved as full and relevant by the Department for Education (DfE).
+      </div>
+
+      <h2 class="govuk-heading-m">
+        Tips for searching the EYQL using this service
+      </h2>
+
+      <p>
+        If you cannot find a qualification that you think should appear on the EYQL, try:
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>checking your spelling</li>
+          <li>using fewer words from the qualification title</li>
+          <li>checking the qualification name and awarding organisation with the candidate</li>
+          <li>asking the candidate to provide a copy of their certificate</li>
+          <li>adding or removing filters on the search page</a>
+        </ul>
+      </p>
+
+      <p>
+        If you need further clarification, contact Ecctis Early Years Service. Ecctis provides qualification checking guidance on behalf of DfE. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on their website.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        Full and relevant qualifications which do not appear on the EYQL
+      </h2>
+
+      <!-- <p>
+        The only qualifications which appear on the EYQL, and in this service, are those which are approved as full and relevant by DfE. The qualification name on the certificate must exactly match the one on the EYQL.
+      </p> -->
+
+      <h3 class="govuk-heading-s">
+        Level 2 qualifications started between 1 September 2014 and 31 August 2019
+      </h3>
+
+      <p>
+        Level 2 qualifications awarded from 1 September 2014 until 31 August 2019 are not shown here. All level 2 early years qualifications are full and relevant if they are:
+      </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>early years (0 to 5 years) related and appropriate to early years practice</li>
+          <li>Ofqual-approved and included on their <a href="#">list of regulated qualifications</a></li>
+        </ul>
+
+
+      <h3 class="govuk-heading-s">
+        Qualifications offered by multiple awarding organisations
+      </h3>
+
+      <p>
+        There are some qualifications which are offered by multiple awarding organisations. These are listed on the EYQL and in this service with the awarding organisation name "Various".
+      </p>
+      <p>
+        If the qualification name matches the certificate, and the specific course meets all the requirements shown on the qualification details page, then it can be considered approved as full and relevant.
+      </p>
+
+      <h3 class="govuk-heading-s">
+        New qualifications
+      </h3>
+
+      <p>
+        If a qualification has not yet been reviewed against the DfE criteria to be approved as full and relevant, it will not appear on the list.
+      </p>
+      <p>
+        Awarding organisations and training providers can apply to DfE to have their qualifications reviewed against the criteria. If they are approved as full and relevant, they will be added to the EYQL and this service.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        About full and relevant qualifications
+      </h2>
+
+      <p>
+        The <a href="">EYFS statutory framework</a> sets out the requirements for staff to child ratios in settings delivering the EYFS and the qualification levels practitioners must hold to be included within those requirements.
+      </p>
+      <p>
+        The <a href="#">Early years qualification requirements and standards document</a> defines the qualifications that practitioners must hold to be included in the specified staff to child ratios at levels 2, 3 and 6 of the EYFS.
+      </p>
+      <p>
+        To be included in the staff to child ratios at level 2, level 3 or level 6, staff must hold a qualification that is recognised by the Department for Education as full and relevant at the appropriate level. Any individual that does not hold a full and relevant qualification can only work as an unqualified member of staff in an early years setting and therefore cannot count in the staff to child ratios.
+      </p>
+      <p>
+        Providers must refer to the EYFS statutory framework for any additional requirements that staff must meet to be included in the staff to child ratios (for example, Paediatric First Aid training).
+      </p>
+      <p>
+        You can read more about the level 2, 3 and 6 staff to child ratios, and the criteria for qualifications to be added to the EYQL in the <a href="#">Early years qualification requirements and standards document</a>.
+
+      <h2 class="govuk-heading-m">
+        Get more help and advice
+      </h2>
+
+      <p>
+        If you need more help with checking early years qualifications, contact Ecctis Early Years Service. Ecctis provides qualification checking guidance on behalf of DfE. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on their website.
+      </p>
+
+      <p>
+        Your local authority’s adult education service can help you find training courses in your local area. You can <a href="https://www.gov.uk/find-local-council">find your local authority on GOV.UK</a>.
+      </p>
+
+      <p>
+        You can find out more about <a href="https://www.gov.uk/government/publications/pathway-into-early-years-education/pathway-into-early-years-education">pathways into early years and childcare on GOV.UK</a>. You should check that any qualification you intend to take meets the requirements and is listed on the Early Years Qualifications List (EYQL).
+      </p>
+
+      <p>
+        Free level 3 early years qualifications are available through the <a href="https://www.gov.uk/government/news/adults-to-gain-new-skills-on-400-free-courses">Lifetime Skills Guarantee</a> for adults:
+      </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>who do not already have a level 3 or higher qualification</li>
+          <li>who are unemployed or earning below the National Living Wage annually (£18,525), regardless of any other qualifications held</li>
+        </ul>
+      <p>
+        Students aged between 16 and 19 may be able to access <a href="https://www.gov.uk/guidance/16-to-19-education-financial-support-for-students">financial support</a> during their studies.
+      </p>
+
+
+
+
+
+
+
+
+
+      <button class="govuk-link govuk-body-s gem-c-print-link__button">Print this page</button>
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="govuk-prototype-kit-common-templates-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Related content
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Check another qualification
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years foundation stage statutory framework (EYFS)
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualification requirements and standards
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Pathway into early years education
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications achieved outside the United Kingdom
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Early years qualifications that do not meet the criteria
+              </a>
+            </li>
+            <!-- <li>
+              <a href="#" class="govuk-!-font-weight-bold">
+                More <span class="govuk-visually-hidden">in Subsection</span>
+              </a>
+            </li> -->
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/current/r10/q1.html
+++ b/app/views/current/r10/q1.html
@@ -1,0 +1,56 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "/current/r10/start"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="q2" method="post">
+
+      {{ govukRadios({
+          name: "awarding-location",
+          value: data['awarding-location'],
+          fieldset: {
+            legend: {
+              text: "Where was the qualification awarded?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "England",
+              text: "England"
+            },
+            {
+              value: "Scotland, Wales or Northern Ireland",
+              text: "Scotland, Wales or Northern Ireland"
+            },
+            {
+              value: "Outside the United Kingdom",
+              text: "Outside the United Kingdom"
+            }
+          ]
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/q1outsideuk.html
+++ b/app/views/current/r10/q1outsideuk.html
@@ -1,0 +1,34 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "/current/r10/start"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">Qualifications achieved outside the United Kingdom</h1>
+
+    <p class="govuk-body">If you did not get your qualification in the United Kingdom you will have to make an application for recognition to work in early years education in England.</p>
+    <br>
+    <p class="govuk-body">The early years qualifications achieved outside the United Kingdom guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the EYFS staff to child ratios in England.</p>
+    <br>
+    <p class="govuk-body">This applies to those in:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Europe</li>
+      <li>Rest of the world</li>
+    </ul>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/q1scotwalirl.html
+++ b/app/views/current/r10/q1scotwalirl.html
@@ -1,0 +1,34 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "/current/r10/start"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">Qualifications achieved in Scotland, Wales or Northern Ireland</h1>
+
+    <!-- <p class="govuk-body">If you did not get your qualification in the United Kingdom you will have to make an application for recognition to work in early years education in England.</p>
+    <br>
+    <p class="govuk-body">The early years qualifications achieved outside the United Kingdom guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the EYFS staff to child ratios in England.</p>
+    <br>
+    <p class="govuk-body">This applies to those in:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Europe</li>
+      <li>Rest of the world</li>
+    </ul> -->
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/q2.html
+++ b/app/views/current/r10/q2.html
@@ -15,35 +15,43 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
     <form class="form" action="q3" method="post">
 
       <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
-      {{ govukRadios({
-          name: "awarding-date",
-          value: data['awarding-date'],
-          fieldset: {
-            legend: {
-              text: "When was the qualification started?",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
-            }
-          },
-          items: [
-            {
-              value: "before",
-              text: "Before September 2014"
-            },
-            {
-              value: "after",
-              text: "On or after 1 September 2014"
-            }
-          ]
-        }) }}
+      {% call govukFieldset({
+        legend: {
+          text: "When was the qualification started?",
+          classes: "govuk-fieldset__legend--l",
+          isPageHeading: true
+        }
+      }) %}
+      <div id="date-format-hint" class="govuk-hint">
+        For example, 3 2014
+      </div>
+        <div class="govuk-date-input" id="date-started">
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="date-started-month">
+                Month
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date-started-month" name="date-started-month" type="text" inputmode="numeric" value="{{data['date-started-month']}}">
+            </div>
+          </div>
+          <div class="govuk-date-input__item">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-date-input__label" for="date-started-year">
+                Year
+              </label>
+              <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-started-year" name="date-started-year" type="text" inputmode="numeric" value="{{data['date-started-year']}}">
+            </div>
+          </div>
+        </div>
 
       {{ govukButton({
         text: "Continue"
       }) }}
+
+      {% endcall %}
 
     </form>
 

--- a/app/views/current/r10/q2.html
+++ b/app/views/current/r10/q2.html
@@ -1,0 +1,53 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "/current/r10/q1"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="q3" method="post">
+
+      <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
+      {{ govukRadios({
+          name: "awarding-date",
+          value: data['awarding-date'],
+          fieldset: {
+            legend: {
+              text: "When was the qualification started?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "before",
+              text: "Before September 2014"
+            },
+            {
+              value: "after",
+              text: "On or after 1 September 2014"
+            }
+          ]
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/q3.html
+++ b/app/views/current/r10/q3.html
@@ -1,0 +1,92 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "/current/r10/q2"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">What level is the qualification?</h1>
+
+            <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            How do I find out what level it is?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>Most qualifications have a difficulty level. The higher the level, the more difficult the qualification is.</p>
+          <p>To find the level of a qualification, you can:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>check the qualification certificate</li>
+            <li>ask the person who holds the qualification</li>
+            <li>see <a href="https://www.gov.uk/what-different-qualification-levels-mean" class="govuk-link" rel="noreferrer noopener" target="_blank">examples of qualification levels</a> in England, Wales and Northern Ireland</li>
+          </ul>
+        </div>
+      </details>
+
+<form class="form" action="set-awarding-orgs" method="post">
+      <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
+      <input type="hidden" name="awarding-date" value="{{data['awarding-date']}}" />
+      {{ govukRadios({
+          name: "qualification-level",
+          value: data['qualification-level'],
+          fieldset: {
+            legend: {
+              text: "",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "2",
+              text: "Level 2"
+            },
+            {
+              value: "3",
+              text: "Level 3"
+            },
+            {
+              value: "4",
+              text: "Level 4"
+            },
+            {
+              value: "5",
+              text: "Level 5"
+            },
+            {
+              value: "6",
+              text: "Level 6"
+            },
+            {
+              value: "7",
+              text: "Level 7"
+            },
+            {
+              value: "8",
+              text: "Level 8"
+            }
+          ]
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/q3.html
+++ b/app/views/current/r10/q3.html
@@ -37,7 +37,8 @@
 
 <form class="form" action="set-awarding-orgs" method="post">
       <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
-      <input type="hidden" name="awarding-date" value="{{data['awarding-date']}}" />
+      <input type="hidden" name="date-started-month" value="{{data['date-started-month']}}" />
+      <input type="hidden" name="date-started-year" value="{{data['date-started-year']}}" />
       {{ govukRadios({
           name: "qualification-level",
           value: data['qualification-level'],

--- a/app/views/current/r10/q3l21419.html
+++ b/app/views/current/r10/q3l21419.html
@@ -1,0 +1,31 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back",
+  href: "/current/r10/start"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">Level 2 qualifications started between 1 September 2014 and 31 August 2019</h1>
+
+    <p class="govuk-body">Level 2 qualifications started between 1 September 2014 and 31 August 2019 are not shown in this service.</p>
+    <p class="govuk-body">All level 2 early years qualifications are full and relevant if they are:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>early years (0 to 5 years) related and appropriate to early years practice</li>
+      <li><a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">Ofqual-approved and included on their list of regulated qualifications</li>
+    </ul>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/q4.html
+++ b/app/views/current/r10/q4.html
@@ -22,7 +22,8 @@ href: "/current/r10/q3"
 
     <form class="form" action="post-search-results" method="post">
       <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
-      <input type="hidden" name="awarding-date" value="{{data['awarding-date']}}" />
+      <input type="hidden" name="date-started-month" value="{{data['date-started-month']}}" />
+      <input type="hidden" name="date-started-year" value="{{data['date-started-year']}}" />
       <input type="hidden" name="qualification-level" value="{{data['qualification-level']}}" />
       <div class="govuk-radios" data-module="govuk-radios">
 

--- a/app/views/current/r10/q4.html
+++ b/app/views/current/r10/q4.html
@@ -1,0 +1,53 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+text: "Back",
+href: "/current/r10/q3"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      What is the awarding organisation?
+    </h1>
+
+    <form class="form" action="post-search-results" method="post">
+      <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
+      <input type="hidden" name="awarding-date" value="{{data['awarding-date']}}" />
+      <input type="hidden" name="qualification-level" value="{{data['qualification-level']}}" />
+      <div class="govuk-radios" data-module="govuk-radios">
+
+        <div class="govuk-form-group">
+
+          {{ govukSelect({
+            id: "awarding-organisation",
+            name: "awarding-organisation",
+            label: {
+              text: "Awarding organisation",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            },
+            items: data['awarding-organisations']
+          }) }}
+        </div>
+      </div>
+
+      {{ govukButton({
+      text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/qualification-detail.html
+++ b/app/views/current/r10/qualification-detail.html
@@ -1,0 +1,139 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <span class="govuk-caption-xl gem-c-title__context">
+       Early Years Qualification List
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        {{ data['qualification'].name }}
+      </h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: data['qualification'].awardingOrganisation
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Level"
+            },
+            value: {
+              text: "Level " + data['qualification'].level
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date started"
+            },
+            value: {
+              text: data['qualification'].dateStarted
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Date of check"
+            },
+            value: {
+              text: "21 February 2024"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      <p>
+        This qualification is approved by the Department for Education as full and relevant, subject to the following notes:
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>The course must be assessed within the EYFS in an Early Years setting in England. </li>
+        </ul>
+      </p>
+
+      <p>
+        This is a level 3 qualification which was started before 1 September 2014. Someone who holds this qualification can be included in staff:child ratios at level 3, as long as they meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">Early Years Foundation Stage</a>.
+      </p>
+
+      <p>
+        If they do not meet all other requirements to be included in the level 3 staff:child ratios, they may be able to work in the level 2 ratios.
+      </p>
+
+      <h2 class="govuk-heading-m">
+        Bookmark a link to this qualification check
+      </h2>
+
+      <p>
+        A permanent link to this qualification check is available at:
+        <br />
+        <br />
+        <a href="#">https://check-early-years-qualification.service.gov.uk/qualification-check/601-3117-2</a>
+      </p>
+
+      <form action="#" method="post" novalidate>
+
+        {{ govukButton({
+          text: "Bookmark this qualification check",
+          classes: "govuk-button--secondary"
+        }) }}
+
+      </form>
+
+      <h2 class="govuk-heading-m">
+        Check another qualification
+      </h2>
+      <p>Return to the start of the <a href="start.html">Check an early years qualification</a> service to check another qualification.</p>
+
+      <h2 class="govuk-heading-m">
+        Further information about the Early Years Qualification List
+      </h2>
+
+      <p>For information on non-UK qualifications, refer to the <a href="https://www.gov.uk/government/publications/early-years-qualifications-achieved-outside-england" class="govuk-link">early years qualifications achieved outside the United Kingdom</a> guidance.</p>
+
+      <div class="govuk-inset-text">
+        <p>
+          If you have further queries, contact Ecctis. Information on the <a rel="external" href="https://ecctis.com/Qualifications/eys/Default.aspx" class="govuk-link">guidance Ecctis is able to provide</a> can be found on its website.
+        </p>
+
+        <p>
+          If you contacted the DfE early years workforce team prior to 5 September 2022, you do not need to contact Ecctis.
+        </p>
+      </div>
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/current/r10/search-results.html
+++ b/app/views/current/r10/search-results.html
@@ -26,7 +26,9 @@ href: "/current/r10/q4"
     <ul class="govuk-list govuk-list--bullet">
       <li>{{ 'Any level' if data['qualification-level'] == 'any' else 'Level ' + data['qualification-level'] }}</li>
       <li>{{ 'Any organisation' if data['awarding-organisation'] == 'any' else data['awarding-organisation']}}</li>
-      <li>{{ 'Before September 2014' if data['awarding-date'] == 'before' else 'On or after 1 September 2014' }}</li>
+      {% if data['awarding-date'] == 'before' %}<li>Before September 2014</li> {% endif %}
+      {% if data['awarding-date'] == 'after' %}<li>On or after 1 September 2014</li> {% endif %}
+      {% if data['awarding-date'] == '2024' %}<li>On or after 1 September 2024</li> {% endif %}
     </ul>
 
     <p class="govuk-body">
@@ -41,6 +43,8 @@ href: "/current/r10/q4"
       <input type="hidden" name="awarding-date" value="{{data['awarding-date']}}" />
       <input type="hidden" name="qualification-level" value="{{data['qualification-level']}}" />
       <input type="hidden" name="awarding-organisation" value="{{data['awarding-organisation']}}" />
+      <input type="hidden" name="date-started-month" value="{{data['date-started-month']}}" />
+      <input type="hidden" name="date-started-year" value="{{data['date-started-year']}}" />
 
       <h1 class="govuk-heading-xl">Select the qualification</h1>
 

--- a/app/views/current/r10/search-results.html
+++ b/app/views/current/r10/search-results.html
@@ -1,0 +1,89 @@
+{% extends "layouts/dfe-main.html" %}
+
+{% block pageTitle %}
+Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+text: "Back",
+href: "/current/r10/q4"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-one-third">
+
+    <h1 class="govuk-label-wrapper">
+      <label class="govuk-label govuk-label--m" for="event-name">
+        Your search
+      </label>
+    </h1>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{ 'Any level' if data['qualification-level'] == 'any' else 'Level ' + data['qualification-level'] }}</li>
+      <li>{{ 'Any organisation' if data['awarding-organisation'] == 'any' else data['awarding-organisation']}}</li>
+      <li>{{ 'Before September 2014' if data['awarding-date'] == 'before' else 'On or after 1 September 2014' }}</li>
+    </ul>
+
+    <p class="govuk-body">
+      <a href="q1" class="govuk-link">Change my search</a>
+    </p>
+
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <form class="form" action="/current/r10/post-search-results" method="post">
+      <input type="hidden" name="awarding-location" value="{{data['awarding-location']}}" />
+      <input type="hidden" name="awarding-date" value="{{data['awarding-date']}}" />
+      <input type="hidden" name="qualification-level" value="{{data['qualification-level']}}" />
+      <input type="hidden" name="awarding-organisation" value="{{data['awarding-organisation']}}" />
+
+      <h1 class="govuk-heading-xl">Select the qualification</h1>
+
+      <p class="govuk-body-l"><strong>{{ data['result-count'] }} matching {{ ' qualifications' if data['result-count']
+          > 1 else ' qualification' }} </strong></p>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          To be full and relevant, the qualification name must exactly match the qualification on the certificate, including any wording in brackets.
+          </strong>
+      </div>
+
+      <div class="govuk-form-group">
+        <label style="margin-bottom:-20px;" class="govuk-label" for="search">
+          Refine your search by entering keywords from the qualification name
+        </label>
+      </div>
+      <div class="govuk-form-group">
+        <input class="govuk-input govuk-!-width-three-quarters" id="" name="qualification-search" type="text" value="{{data['qualification-search']}}">
+        {{govukButton({
+          text: "Search",
+          type: "Submit",
+          classes: "govuk-button--secondary"
+          })}}       
+      </div>
+
+      <ul class="govuk-list govuk-list--spaced">
+        {% for qualification in data['search-results'] %}
+        <li>
+          <div>
+            <h2><a href={{qualification.href}}>{{qualification.name}}</a></h2>
+            <p>This qualification has 2 additional requirements</p>
+            <p><strong>Level:</strong> {{qualification.level}}</p>
+            <p><strong>Awarding organisation:</strong> {{qualification.awardingOrganisation}}</p>
+          </div>
+          <hr />
+        </li>
+        {% endfor %}
+      </ul>
+  </div>
+  </form>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/start.html
+++ b/app/views/current/r10/start.html
@@ -1,0 +1,70 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Start – {{ serviceName }} – GOV.UK Prototype
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "#"
+      },
+      {
+        text: "Education, training and skills",
+        href: "#"
+      },
+      {
+        text: "Check an early years qualification"
+      }
+    ]
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        {{ serviceName }}
+      </h1>
+
+      <p>Use this service to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>check if an early years qualification is approved by the Department for Education (DfE) as full and relevant</li>
+        <li>confirm if someone who holds this qualification can count in staff to child ratios at level 2, 3 or 6</li>
+      </ul>
+
+      <h2 class="govuk-heading-m">Before you start</h2>
+
+      <p>
+        To confirm if the qualification is full and relevant, this service will ask you about:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>if the qualification was awarded in the UK or overseas</li>
+        <li>the level of the qualification</li>
+        <li>the date that the qualification was started</li>
+        <li>the awarding organisation</li>
+      </ul>
+
+      <p>
+        Some qualifications have additional requirements which need to be met for the qualification to be considered full and relevant. This service will tell you if any additional requirements apply, and what these are.
+      </p>
+
+      <form class="form" action="/current/r10/q1" method="post">
+        {{ govukButton({
+          text: "Start now",
+          type: "Submit",
+          isStartButton: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -17,6 +17,7 @@
     <h2 class="govuk-heading-s">Beta</h2>
     <span class="govuk-caption-m gem-c-title__context">May 2024</span>
     <ul>
+      <li><a href="current/r10/start">Round 6 UR</a></li>
       <li><a href="current/r9/start">Round 5 UR</a></li>
     </ul>
 


### PR DESCRIPTION
Updated the prototype to:

- Amend the ‘When was the qualification started?’ page to include the month / year fields

- The Awarding Organisations should be filtered based on the start date and levels to reduce the numbers in the list

- Clear the data when someone clicks the ‘Check another qualification’