### PR TITLE
Removed EYQ-22 and EYQ-65 for UR

### DIFF
--- a/app/data/qualifications.json
+++ b/app/data/qualifications.json
@@ -1892,20 +1892,6 @@
             "href":"eyq-219"
         },
         {
-            "id":"EYQ-22",
-            "level":3,
-            "dateStarted":null,
-            "dateEnd":"Aug-14",
-            "name":"Advanced Certificate in Playgroup Practice",
-            "awardingOrganisation":"NCFE",
-            "qualificationNumber":null,
-            "notes":null,
-            "additionalRequirements":null,
-            "additionalRequirementsNumber":0,
-            "beforeOrAfter2014":"before",
-            "href":"eyq-22"
-        },
-        {
             "id":"EYQ-220",
             "level":2,
             "dateStarted":"2019",
@@ -3850,20 +3836,6 @@
             "additionalRequirementsNumber":0,
             "beforeOrAfter2014":"before",
             "href":"eyq-64"
-        },
-        {
-            "id":"EYQ-65",
-            "level":3,
-            "dateStarted":null,
-            "dateEnd":"Aug-14",
-            "name":"NCFE Advanced Certificate in Playwork",
-            "awardingOrganisation":"NCFE",
-            "qualificationNumber":null,
-            "notes":null,
-            "additionalRequirements":null,
-            "additionalRequirementsNumber":0,
-            "beforeOrAfter2014":"before",
-            "href":"eyq-65"
         },
         {
             "id":"EYQ-66",


### PR DESCRIPTION
Our sample qualification for UR will be an NCFE qualification, but we want users to try and find it by choosing the Not in list option for Various awarding organisations. I'm removing these two qualifications so NCFE doesn't appear on the dropdown list of awarding orgs.