### PR TITLE
Added new qual pages for 75 and 293

### DIFF
--- a/app/data/qualifications.json
+++ b/app/data/qualifications.json
@@ -27,7 +27,7 @@
             "additionalRequirements":null,
             "additionalRequirementsNumber":2,
             "beforeOrAfter2014":"after",
-            "href":"eyq-293"
+            "href":"eyq-293-confirm"
         },
         {
             "id":"EYQ-10",
@@ -3989,7 +3989,7 @@
             "additionalRequirements":null,
             "additionalRequirementsNumber":0,
             "beforeOrAfter2014":"before",
-            "href":"eyq-75"
+            "href":"eyq-75-confirm"
         },
         {
             "id":"EYQ-76",

--- a/app/views/current/r10/eyq-293-checked.html
+++ b/app/views/current/r10/eyq-293-checked.html
@@ -1,0 +1,265 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Select the qualification",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">
+        Your result
+      </h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+              {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "Degrees and honours degrees at Level 6"
+            }
+          },
+
+        {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+              key: {
+                text: "Awarding organisation"
+              },
+              value: {
+                text: "Various awarding organisations"
+              },
+              actions: {
+
+              }
+            }
+            ,
+          {
+              key: {
+                text: "Date added to early years qualifications list"
+              },
+              value: {
+                text: "1 September 2014"
+              },
+              actions: {
+
+              }
+            }
+            ,
+          {
+            key: {
+              text: "Date checked"
+            },
+            value: {
+              text: data['todays-date']
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+      <p class="govuk-body-l"><strong>Your answers</strong></p>
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Did the qualification include an <a href="">element of assessed practice in an early years setting</a>?
+</p>
+</legend>
+  <p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+    Yes
+  </p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Was the course fully consistent with the <a href="">QAA subject benchmark statement for Early Childhood Studies</a>?
+</p>
+</legend>
+<p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+  Yes
+</p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+            <p class="govuk-body">
+        <a href="eyq-293" class="govuk-link">Change my answers</a>
+      </p>
+
+      <br>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided.
+        </strong>
+      </div>
+
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+
+
+                  <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Unqualified</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to work as an unqualified member of staff
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
+
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Level 2</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to count in the level 2 staff to child ratios
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+              Level 3</strong>
+            </p>
+          </legend>
+          <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+            Approved
+          </p>
+          <details class="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Other requirements to count in the level 3 staff to child ratios
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+              <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
+              <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+            </ul>
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+              </p>
+            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+          </div>
+        </details>
+        </fieldset>
+      </div>
+      <hr>
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+       Level 6</strong>
+      </p>
+    </legend>
+    <p style="margin-left:850px; margin-top:-60px; background-color:red; color: white;" class="govuk-tag govuk-tag--green">
+    Not approved
+    </p>
+    <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Requirements to work at level 6
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Qualified Teacher Status</li>
+        <li>Early Years Teacher Status</li>
+        <li>Early Years Professional Status (EYPS)</li>
+      </ul>
+      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+    </div>
+  </details>
+  </fieldset>
+</div>
+<hr>
+
+<br>
+<button onclick="window.print();" class="govuk-link govuk-body-s gem-c-print-link__button">Print this page</button>
+
+<br><br>
+<p class="govuk-body">
+<a href="/reset-filters" class="govuk-link">Check another qualification</a>
+</p>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-293-confirm-error.html
+++ b/app/views/current/r10/eyq-293-confirm-error.html
@@ -1,0 +1,112 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back to Select the qualification",
+  href: "/current/r10/search-results"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <form class="form" action="confirm-post" method="post">
+      <input type="hidden" name="redirect" value="eyq-293" />
+
+      {% set errorMessage = "Please tell us if this is the qualification you are looking for" %}
+
+      {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: [
+          {
+            text: errorMessage,
+            href: "#yes-no"
+          }
+        ]
+      }) }}
+
+      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "Degrees and honours degrees at Level 6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "Various awarding organisations"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukRadios({
+          name: "yes-no",
+          value: data['yes-no'],
+          fieldset: {
+            legend: {
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              text: "No, search again"
+            },
+            {
+            }
+          ],
+          errorMessage: {
+            text: errorMessage
+          }
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/eyq-293-confirm-error.html
+++ b/app/views/current/r10/eyq-293-confirm-error.html
@@ -19,7 +19,7 @@
     <form class="form" action="confirm-post" method="post">
       <input type="hidden" name="redirect" value="eyq-293" />
 
-      {% set errorMessage = "Please tell us if this is the qualification you are looking for" %}
+      {% set errorMessage = "Confirm if this is the qualification you are looking for" %}
 
       {{ govukErrorSummary({
         titleText: "There is a problem",
@@ -31,7 +31,7 @@
         ]
       }) }}
 
-      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+      <h1 class="govuk-heading-xl">Confirm qualification</h1>
 
       {{ govukSummaryList({
         rows: [
@@ -71,16 +71,30 @@
 
             }
           }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
         ]
       }) }}
 
       {{ govukRadios({
+          id: "yes-no",
           name: "yes-no",
           value: data['yes-no'],
           fieldset: {
             legend: {
+              text: "Is this the qualification you are looking for?",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              classes: "govuk-fieldset__legend--s"
             }
           },
           items: [
@@ -90,9 +104,7 @@
             },
             {
               value: "No",
-              text: "No, search again"
-            },
-            {
+              text: "No, select another qualification"
             }
           ],
           errorMessage: {

--- a/app/views/current/r10/eyq-293-confirm.html
+++ b/app/views/current/r10/eyq-293-confirm.html
@@ -1,0 +1,97 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back to Select the qualification",
+  href: "/current/r10/search-results"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <form class="form" action="confirm-post" method="post">
+      <input type="hidden" name="redirect" value="eyq-293" />
+
+      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "Degrees and honours degrees at Level 6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "Various awarding organisations"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukRadios({
+          name: "yes-no",
+          value: data['yes-no'],
+          fieldset: {
+            legend: {
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              text: "No, search again"
+            },
+            {
+            }
+          ]
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/eyq-293-confirm.html
+++ b/app/views/current/r10/eyq-293-confirm.html
@@ -19,7 +19,7 @@
     <form class="form" action="confirm-post" method="post">
       <input type="hidden" name="redirect" value="eyq-293" />
 
-      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+      <h1 class="govuk-heading-xl">Confirm qualification</h1>
 
       {{ govukSummaryList({
         rows: [
@@ -59,6 +59,18 @@
 
             }
           }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "1 September 2014"
+            },
+            actions: {
+
+            }
+          }
         ]
       }) }}
 
@@ -67,8 +79,9 @@
           value: data['yes-no'],
           fieldset: {
             legend: {
+              text: "Is this the qualification you are looking for?",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              classes: "govuk-fieldset__legend--s"
             }
           },
           items: [
@@ -78,9 +91,7 @@
             },
             {
               value: "No",
-              text: "No, search again"
-            },
-            {
+              text: "No, select another qualification"
             }
           ]
         }) }}

--- a/app/views/current/r10/eyq-293.html
+++ b/app/views/current/r10/eyq-293.html
@@ -1,0 +1,177 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Select the qualification",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+
+      <h1 class="govuk-heading-xl">
+        Check the additional requirements
+      </h1>
+
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "Degrees and honours degrees at Level 6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "6"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "Various awarding organisations"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+
+            <div style="margin-top:50px;" class="govuk-inset-text">
+        You can bookmark this page if you need to return to it later
+      </div>
+
+    </div>
+  </div>
+
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p style="margin-top:25px;" class="govuk-body-l"><strong>Please answer the following questions</strong></p>
+
+
+
+<!--      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <div style="padding-left:740px; margin-top:-70px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014" name="sep2014" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="sep2014">
+          Yes
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="sep2014-2" name="sep2014" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="sep2014-2">
+          No
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<hr> -->
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em;" class="govuk-body-m">
+  Did the qualification include an <a href="">element of assessed practice in an early years setting</a>?
+</p>
+</legend>
+<div style="padding-left:740px; margin-top:-80px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears" name="earlyyears" type="radio" value="yes">
+  <label class="govuk-label govuk-radios__label" for="earlyyears">
+    Yes
+  </label>
+</div>
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="earlyyears-2" name="earlyyears" type="radio" value="no">
+  <label class="govuk-label govuk-radios__label" for="earlyyears-2">
+    No
+  </label>
+</div>
+</div>
+</fieldset>
+</div>
+<hr>
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em;" class="govuk-body-m">
+  Was the course fully consistent with the <a href="">QAA subject benchmark statement for Early Childhood Studies</a>?
+</p>
+</legend>
+<div style="padding-left:740px; margin-top:-80px;" class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="QAA" name="QAA" type="radio" value="yes">
+  <label class="govuk-label govuk-radios__label" for="QAA">
+    Yes
+  </label>
+</div>
+<div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="QAA-2" name="QAA" type="radio" value="no">
+  <label class="govuk-label govuk-radios__label" for="QAA-2">
+    No
+  </label>
+</div>
+</div>
+</fieldset>
+</div>
+<hr>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+        </strong>
+      </div>
+
+      <form class="form" action="/current/r10/eyq-293-checked" method="post">
+            {{ govukButton({
+        text: "Get result"
+      }) }}
+      </form>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-75-checked.html
+++ b/app/views/current/r10/eyq-75-checked.html
@@ -1,0 +1,272 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Check an Early Years qualification – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Select the qualification",
+    href: "/current/r10/search-results"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      <h1 class="govuk-heading-xl">
+        Your result
+      </h1>
+
+        {{ govukSummaryList({
+          rows: [
+
+                {
+              key: {
+                text: "Qualification"
+              },
+              value: {
+                text: "Diploma for the Children and Young People's Workforce (Early Learning and Childcare)"
+              }
+            },
+
+          {
+              key: {
+                text: "Qualification level"
+              },
+              value: {
+                text: "3"
+              },
+              actions: {
+
+              }
+            }
+            ,
+            {
+                key: {
+                  text: "Awarding organisation"
+                },
+                value: {
+                  text: "Various awarding organisations"
+                },
+                actions: {
+
+                }
+              }
+              ,
+            {
+                key: {
+                  text: "Date added to early years qualifications list"
+                },
+                value: {
+                  text: "Before September 2014"
+                },
+                actions: {
+
+                }
+              }
+              ,
+            {
+              key: {
+                text: "Date checked"
+              },
+              value: {
+                text: data['todays-date']
+              },
+              actions: {
+
+              }
+            }
+          ]
+        }) }}
+
+
+
+    </div>
+  </div>
+<!--
+  <div style="margin-left:-5px;" class="govuk-grid-row">
+    <div class="full-width-container">
+
+
+
+      <p class="govuk-body-l"><strong>Your answers</strong></p>
+
+
+
+      <div style="margin-top:40px;" class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="max-width:35em; margin-bottom:20px;" class=class="govuk-body-m">
+        Was the qualification registered for or started after September 2014?
+      </p>
+    </legend>
+    <p style="padding-left:900px; margin-top:-60px;" class=class="govuk-body-m">
+      Yes
+    </p>
+  </fieldset>
+</div>
+<hr style="margin-top:-20px;">
+
+<div class="govuk-form-group">
+<fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+<p style="max-width:35em; margin-top:30px;" class="govuk-body-m">
+  Does the qualification name include Early Years Educator?
+</p>
+</legend>
+  <p style="padding-left:900px; margin-top:-75px;" class=class="govuk-body-m">
+    Yes
+  </p>
+</fieldset>
+</div>
+<hr style="margin-top:-30px;">
+
+            <p class="govuk-body">
+        <a href="eyq-224" class="govuk-link">Change my answers</a>
+      </p>
+
+    -->
+
+      <br>
+
+      <div style="max-width:35em;" class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-visually-hidden">Warning</span>
+          Your result is dependent on the accuracy of the answers you have provided.
+        </strong>
+      </div>
+
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+
+
+                  <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Unqualified</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to work as an unqualified member of staff
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
+
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+                    Level 2</strong>
+                  </p>
+                </legend>
+                <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+                  Approved
+                </p>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to count in the level 2 staff to child ratios
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+              Level 3</strong>
+            </p>
+          </legend>
+          <p style="margin-left:885px; margin-top:-60px; background-color:#008A0D; color: white;" class="govuk-tag govuk-tag--green">
+            Approved
+          </p>
+          <details class="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Other requirements to count in the level 3 staff to child ratios
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+              <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
+              <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+            </ul>
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+              </p>
+            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+          </div>
+        </details>
+        </fieldset>
+      </div>
+      <hr>
+
+      <div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <p style="padding-top:30px; margin-bottom:-30px;"  class="govuk-body-m"><strong>
+       Level 6</strong>
+      </p>
+    </legend>
+    <p style="margin-left:850px; margin-top:-60px; background-color:red; color: white;" class="govuk-tag govuk-tag--green">
+    Not approved
+    </p>
+    <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Requirements to work at level 6
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Qualified Teacher Status</li>
+        <li>Early Years Teacher Status</li>
+        <li>Early Years Professional Status (EYPS)</li>
+      </ul>
+      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+    </div>
+  </details>
+  </fieldset>
+</div>
+<hr>
+
+<br>
+<button onclick="window.print();" class="govuk-link govuk-body-s gem-c-print-link__button">Print this page</button>
+
+<br><br>
+<p class="govuk-body">
+<a href="/current/r10/reset-filters" class="govuk-link">Check another qualification</a>
+</p>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/current/r10/eyq-75-confirm-error.html
+++ b/app/views/current/r10/eyq-75-confirm-error.html
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <form class="form" action="confirm-post" method="post">
-      <input type="hidden" name="redirect" value="eyq-75" />
+      <input type="hidden" name="redirect" value="eyq-75-checked" />
 
       {% set errorMessage = "Confirm if this is the qualification you are looking for" %}
 

--- a/app/views/current/r10/eyq-75-confirm-error.html
+++ b/app/views/current/r10/eyq-75-confirm-error.html
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-  text: "Back to select the qualification",
+  text: "Back to Select the qualification",
   href: "/current/r10/search-results"
 }) }}
 {% endblock %}
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <form class="form" action="confirm-post" method="post">
-      <input type="hidden" name="redirect" value="eyq-75-checked" />
+      <input type="hidden" name="redirect" value="eyq-75" />
 
       {% set errorMessage = "Confirm if this is the qualification you are looking for" %}
 
@@ -31,7 +31,7 @@
         ]
       }) }}
 
-      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+      <h1 class="govuk-heading-xl">Confirm qualification</h1>
 
       {{ govukSummaryList({
         rows: [
@@ -71,6 +71,18 @@
 
             }
           }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "Before 1 September 2014"
+            },
+            actions: {
+
+            }
+          }
         ]
       }) }}
 
@@ -80,8 +92,9 @@
           value: data['yes-no'],
           fieldset: {
             legend: {
+              text: "Is this the qualification you are looking for?",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              classes: "govuk-fieldset__legend--s"
             }
           },
           items: [
@@ -91,9 +104,7 @@
             },
             {
               value: "No",
-              text: "No, search again"
-            },
-            {
+              text: "No, select another qualification"
             }
           ],
           errorMessage: {

--- a/app/views/current/r10/eyq-75-confirm-error.html
+++ b/app/views/current/r10/eyq-75-confirm-error.html
@@ -1,0 +1,113 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back to select the qualification",
+  href: "/current/r10/search-results"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <form class="form" action="confirm-post" method="post">
+      <input type="hidden" name="redirect" value="eyq-75-checked" />
+
+      {% set errorMessage = "Confirm if this is the qualification you are looking for" %}
+
+      {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: [
+          {
+            text: errorMessage,
+            href: "#yes-no"
+          }
+        ]
+      }) }}
+
+      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "Diploma for the Children and Young People's Workforce (Early Learning and Childcare)"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "Various awarding organisations"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukRadios({
+          id: "yes-no",
+          name: "yes-no",
+          value: data['yes-no'],
+          fieldset: {
+            legend: {
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              text: "No, search again"
+            },
+            {
+            }
+          ],
+          errorMessage: {
+            text: errorMessage
+          }
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/current/r10/eyq-75-confirm.html
+++ b/app/views/current/r10/eyq-75-confirm.html
@@ -17,9 +17,9 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
     <form class="form" action="confirm-post" method="post">
-      <input type="hidden" name="redirect" value="eyq-224" />
+      <input type="hidden" name="redirect" value="eyq-75-checked" />
 
-      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+      <h1 class="govuk-heading-xl">Confirm qualification</h1>
 
       {{ govukSummaryList({
         rows: [
@@ -59,6 +59,18 @@
 
             }
           }
+          ,
+          {
+            key: {
+              text: "Date added to early years qualifications list"
+            },
+            value: {
+              text: "Before 1 September 2014"
+            },
+            actions: {
+
+            }
+          }
         ]
       }) }}
 
@@ -67,8 +79,9 @@
           value: data['yes-no'],
           fieldset: {
             legend: {
+              text: "Is this the qualification you are looking for?",
               isPageHeading: true,
-              classes: "govuk-fieldset__legend--l"
+              classes: "govuk-fieldset__legend--s"
             }
           },
           items: [
@@ -78,9 +91,7 @@
             },
             {
               value: "No",
-              text: "No, search again"
-            },
-            {
+              text: "No, select another qualification"
             }
           ]
         }) }}

--- a/app/views/current/r10/eyq-75-confirm.html
+++ b/app/views/current/r10/eyq-75-confirm.html
@@ -1,0 +1,97 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Search results for 'NFCE' – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+  text: "Back to Select the qualification",
+  href: "/current/r10/search-results"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    <form class="form" action="confirm-post" method="post">
+      <input type="hidden" name="redirect" value="eyq-224" />
+
+      <h1 class="govuk-heading-xl">Is this the qualification you are looking for?</h1>
+
+      {{ govukSummaryList({
+        rows: [
+
+        {
+            key: {
+              text: "Qualification"
+            },
+            value: {
+              text: "Diploma for the Children and Young People's Workforce (Early Learning and Childcare)"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Qualification level"
+            },
+            value: {
+              text: "3"
+            },
+            actions: {
+
+            }
+          }
+          ,
+          {
+            key: {
+              text: "Awarding organisation"
+            },
+            value: {
+              text: "Various awarding organisations"
+            },
+            actions: {
+
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukRadios({
+          name: "yes-no",
+          value: data['yes-no'],
+          fieldset: {
+            legend: {
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              text: "No, search again"
+            },
+            {
+            }
+          ]
+        }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Added 3 new pages for EYQ-75:
 - eyq-75-confirm
 - eyq-75-confirm-error
 - eyq-75-checked

EYQ-75 doesn't have any additional requirements beyond things we've already asked about so there's no additional requirements page (would have been eyq-75)

Added 4 new pages for eyq-293:
 - eyq-293-confirm
 - eyq-293-confirm-error
 - eyq-293
 - eyq-293-checked

Changed href field in qualifications.json for the two qualifications so they go to the confirm pages.