### PR TITLE
Reorder levels in Your results page for Level 3 to appear first, and …

### DIFF
--- a/app/views/current/r10/eyq-293-checked.html
+++ b/app/views/current/r10/eyq-293-checked.html
@@ -136,71 +136,7 @@
 
       <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
 
-
-                  <div class="govuk-form-group">
-              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
-                <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
-                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                    <p class="govuk-body-m">
-                      <strong>
-                        Unqualified
-                      </strong>
-                    </p>
-                  </legend>
-                  <div style="max-height: max-content;">
-                    <strong class="govuk-tag govuk-tag--green">
-                      Approved
-                    </strong>
-                  </div>
-                </div>
-                <details class="govuk-details">
-                <summary class="govuk-details__summary">
-                  <span class="govuk-details__summary-text">
-                    Other requirements to work as an unqualified member of staff
-                  </span>
-                </summary>
-                <div class="govuk-details__text">
-                  <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
-
-                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
-                </div>
-              </details>
-              </fieldset>
-            </div>
-            <hr>
-
-            <div class="govuk-form-group">
-              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
-                <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
-                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                    <p class="govuk-body-m">
-                      <strong>
-                        Level 2
-                      </strong>
-                    </p>
-                  </legend>
-                  <div style="max-height: max-content;">
-                    <strong class="govuk-tag govuk-tag--green">
-                      Approved
-                    </strong>
-                  </div>
-                </div>
-                <details class="govuk-details">
-                <summary class="govuk-details__summary">
-                  <span class="govuk-details__summary-text">
-                    Other requirements to count in the level 2 staff to child ratios
-                  </span>
-                </summary>
-                <div class="govuk-details__text">
-                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
-                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
-                </div>
-              </details>
-              </fieldset>
-            </div>
-            <hr>
-
-            <div class="govuk-form-group">
+      <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
           <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -238,6 +174,68 @@
         </fieldset>
       </div>
       <hr>
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+                <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <p class="govuk-body-m">
+                      <strong>
+                        Level 2
+                      </strong>
+                    </p>
+                  </legend>
+                  <div style="max-height: max-content;">
+                    <strong class="govuk-tag govuk-tag--green">
+                      Approved
+                    </strong>
+                  </div>
+                </div>
+                <details class="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Other requirements to count in the level 2 staff to child ratios
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+                  <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+                </div>
+              </details>
+              </fieldset>
+            </div>
+            <hr>
+
+            <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+              <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <p class="govuk-body-m">
+                    <strong>
+                      Unqualified
+                    </strong>
+                  </p>
+                </legend>
+                <div style="max-height: max-content;">
+                  <strong class="govuk-tag govuk-tag--green">
+                    Approved
+                  </strong>
+                </div>
+              </div>
+              <details class="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Other requirements to work as an unqualified member of staff
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <p>No qualifications are required to work as an unqualified member of staff in an early years setting. However, as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">early years foundation stage (EYFS) statutory framework</a>, providers must ensure that staffing arrangements meet the needs of all children and ensure their safety.</p>
+
+                <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+              </div>
+            </details>
+            </fieldset>
+          </div>
+          <hr>
 
       <div class="govuk-form-group">
   <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">

--- a/app/views/current/r10/eyq-75-checked.html
+++ b/app/views/current/r10/eyq-75-checked.html
@@ -142,8 +142,75 @@
 
       <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
 
-
       <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+          <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <p class="govuk-body-m">
+                <strong>
+                  Level 3
+                </strong>
+              </p>
+            </legend>
+            <div style="max-height: max-content;">
+              <strong class="govuk-tag govuk-tag--green">
+                Approved
+              </strong>
+            </div>
+          </div>
+      
+          <details class="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Other requirements to count in the level 3 staff to child ratios
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+              <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
+              <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
+            </ul>
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+              </p>
+            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+          </div>
+        </details>
+        </fieldset>
+        <hr>
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
+            <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <p class="govuk-body-m">
+                  <strong>
+                    Level 2
+                  </strong>
+                </p>
+              </legend>
+              <div style="max-height: max-content;">
+                <strong class="govuk-tag govuk-tag--green">
+                  Approved
+                </strong>
+              </div>
+            </div>
+            <details class="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Other requirements to count in the level 2 staff to child ratios
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
+              <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
+            </div>
+          </details>
+          </fieldset>
+        </div>
+        <hr>
+
         <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
           <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -176,74 +243,8 @@
       <hr>
 
       <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
-          <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <p class="govuk-body-m">
-                <strong>
-                  Level 2
-                </strong>
-              </p>
-            </legend>
-            <div style="max-height: max-content;">
-              <strong class="govuk-tag govuk-tag--green">
-                Approved
-              </strong>
-            </div>
-          </div>
-          <details class="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Other requirements to count in the level 2 staff to child ratios
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <p>As this qualification was achieved after 30 June 2016, the member of staff must obtain a paediatric first aid qualification which meets the <a href="">criteria in the early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</p>
-            <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
-          </div>
-        </details>
-        </fieldset>
-      </div>
-      <hr>
-
-      <div class="govuk-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
-    <div style="display: flex; justify-content: space-between; padding-top: 30px; margin-bottom: -24px;">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <p class="govuk-body-m">
-          <strong>
-            Level 3
-          </strong>
-        </p>
-      </legend>
-      <div style="max-height: max-content;">
-        <strong class="govuk-tag govuk-tag--green">
-          Approved
-        </strong>
-      </div>
-    </div>
-
-    <details class="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Other requirements to count in the level 3 staff to child ratios
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
-        <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
-        <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
-      </ul>
-      <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
-        </p>
-      <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
-    </div>
-  </details>
-  </fieldset>
+  
 </div>
-<hr>
 
 <div class="govuk-form-group">
 <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">


### PR DESCRIPTION
- Reordered Levels displayed in 'Your result' page for Level 3 to appear first, then level 2, unqualified and level 6 last