### PR TITLE
Changed 'staff to child ratios' to 'staff:child ratios'

### DIFF
--- a/app/views/current/r10/eyq-223-checked.html
+++ b/app/views/current/r10/eyq-223-checked.html
@@ -138,7 +138,7 @@
         </strong>
       </div>
 
-      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff:child ratios.</strong></p>
 
 
                   <div class="govuk-form-group">
@@ -180,7 +180,7 @@
                 <details class="govuk-details">
                 <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
-                    Other requirements to count in the level 2 staff to child ratios
+                    Other requirements to count in the level 2 staff:child ratios
                   </span>
                 </summary>
                 <div class="govuk-details__text">
@@ -205,17 +205,17 @@
           <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Other requirements to count in the level 3 staff to child ratios
+              Other requirements to count in the level 3 staff:child ratios
             </span>
           </summary>
           <div class="govuk-details__text">
-            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
               <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
               <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
             </ul>
-            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff:child ratios at level 2.
               </p>
             <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
           </div>
@@ -241,13 +241,13 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      To be included in the staff:child ratios at level 6, staff must hold one of the following:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Qualified Teacher Status</li>
         <li>Early Years Teacher Status</li>
         <li>Early Years Professional Status (EYPS)</li>
       </ul>
-      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Staff who hold one of these qualifications may be counted in the staff:child ratios at either level 3 or level 6, but not both.</p>
       <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
     </div>
   </details>

--- a/app/views/current/r10/eyq-224-checked.html
+++ b/app/views/current/r10/eyq-224-checked.html
@@ -141,7 +141,7 @@
         </strong>
       </div>
 
-      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff:child ratios.</strong></p>
 
 
                   <div class="govuk-form-group">
@@ -183,7 +183,7 @@
                 <details class="govuk-details">
                 <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
-                    Other requirements to count in the level 2 staff to child ratios
+                    Other requirements to count in the level 2 staff:child ratios
                   </span>
                 </summary>
                 <div class="govuk-details__text">
@@ -208,17 +208,17 @@
           <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Other requirements to count in the level 3 staff to child ratios
+              Other requirements to count in the level 3 staff:child ratios
             </span>
           </summary>
           <div class="govuk-details__text">
-            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
               <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
               <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
             </ul>
-            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff:child ratios at level 2.
               </p>
             <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
           </div>
@@ -244,13 +244,13 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      To be included in the staff:child ratios at level 6, staff must hold one of the following:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Qualified Teacher Status</li>
         <li>Early Years Teacher Status</li>
         <li>Early Years Professional Status (EYPS)</li>
       </ul>
-      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Staff who hold one of these qualifications may be counted in the staff:child ratios at either level 3 or level 6, but not both.</p>
       <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
     </div>
   </details>

--- a/app/views/current/r10/eyq-293-checked.html
+++ b/app/views/current/r10/eyq-293-checked.html
@@ -134,7 +134,7 @@
         </strong>
       </div>
 
-      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff:child ratios.</strong></p>
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
@@ -156,17 +156,17 @@
           <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Other requirements to count in the level 3 staff to child ratios
+              Other requirements to count in the level 3 staff:child ratios
             </span>
           </summary>
           <div class="govuk-details__text">
-            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
               <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.</li>
               <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
             </ul>
-            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff:child ratios at level 2.
               </p>
           </div>
         </details>
@@ -193,7 +193,7 @@
                 <details class="govuk-details">
                 <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
-                    Other requirements to count in the level 2 staff to child ratios
+                    Other requirements to count in the level 2 staff:child ratios
                   </span>
                 </summary>
                 <div class="govuk-details__text">
@@ -252,17 +252,17 @@
     <details class="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
-        Requirements to count in the level 6 staff to child ratios
+        Requirements to count in the level 6 staff:child ratios
       </span>
     </summary>
     <div class="govuk-details__text">
-      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      To be included in the staff:child ratios at level 6, staff must hold one of the following:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Qualified Teacher Status</li>
         <li>Early Years Teacher Status</li>
         <li>Early Years Professional Status (EYPS)</li>
       </ul>
-      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Staff who hold one of these qualifications may be counted in the staff:child ratios at either level 3 or level 6, but not both.</p>
 
     </div>
   </details>

--- a/app/views/current/r10/eyq-300-checked.html
+++ b/app/views/current/r10/eyq-300-checked.html
@@ -146,7 +146,7 @@
         </strong>
       </div>
 
-      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff:child ratios.</strong></p>
 
 
                   <div class="govuk-form-group">
@@ -200,7 +200,7 @@
                 <details class="govuk-details">
                 <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
-                    Other requirements to count in the level 2 staff to child ratios
+                    Other requirements to count in the level 2 staff:child ratios
                   </span>
                 </summary>
                 <div class="govuk-details__text">
@@ -232,17 +232,17 @@
           <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Other requirements to count in the level 3 staff to child ratios
+              Other requirements to count in the level 3 staff:child ratios
             </span>
           </summary>
           <div class="govuk-details__text">
-            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
               <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
               <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
             </ul>
-            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff:child ratios at level 2.
               </p>
             <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
           </div>
@@ -274,13 +274,13 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+      To be included in the staff:child ratios at level 6, staff must hold one of the following:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>Qualified Teacher Status</li>
         <li>Early Years Teacher Status</li>
         <li>Early Years Professional Status (EYPS)</li>
       </ul>
-      <p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+      <p>Staff who hold one of these qualifications may be counted in the staff:child ratios at either level 3 or level 6, but not both.</p>
       <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
     </div>
   </details>

--- a/app/views/current/r10/eyq-300-v1.html
+++ b/app/views/current/r10/eyq-300-v1.html
@@ -95,14 +95,14 @@
       </div>
 
       <p>
-        This is a level 6 qualification which was started after 1 September 2014. Someone who holds this qualification can be included in staff to child ratios at level 3 as long as they meet all the other level 3 requirements.</p>
+        This is a level 6 qualification which was started after 1 September 2014. Someone who holds this qualification can be included in staff:child ratios at level 3 as long as they meet all the other level 3 requirements.</p>
 
       <h2 class="govuk-heading-m">
-        Other requirements to work in the staff to child ratios at level 3
+        Other requirements to work in the staff:child ratios at level 3
       </h2>
 
       <p>
-        For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:
+        For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
@@ -112,15 +112,15 @@
       </ul>
 
       <p>
-        A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+        A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff:child ratios at level 2.
       </p>
 
       <h2 class="govuk-heading-m">
-      Requirements to work in the staff to child ratios at level 6
+      Requirements to work in the staff:child ratios at level 6
       </h2>
 
       <p>
-        To be included in the staff to child ratios at level 6, staff must hold one of the following or another approved level 6 qualification:
+        To be included in the staff:child ratios at level 6, staff must hold one of the following or another approved level 6 qualification:
       </p>
 
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/current/r10/eyq-301-v1.html
+++ b/app/views/current/r10/eyq-301-v1.html
@@ -84,15 +84,15 @@
       </div>
 
       <p>
-        This is a level 3 qualification which was started before 1 September 2014. Someone who holds this qualification can be included in staff to child ratios at level 3 as long as they meet all the other level 3 requirements.
+        This is a level 3 qualification which was started before 1 September 2014. Someone who holds this qualification can be included in staff:child ratios at level 3 as long as they meet all the other level 3 requirements.
       </p>
 
       <h2 class="govuk-heading-m">
-        Other requirements to work in the staff to child ratios at level 3
+        Other requirements to work in the staff:child ratios at level 3
       </h2>
 
       <p>
-        For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:
+        For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:
       </p>
 
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/current/r10/eyq-75-checked.html
+++ b/app/views/current/r10/eyq-75-checked.html
@@ -140,7 +140,7 @@
         </strong>
       </div>
 
-      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff to child ratios.</strong></p>
+      <p style="max-width:35em;" class="govuk-body-m"><strong>Given the answers you have provided, this qualification is approved by the Department for Education as full and relevant for the following staff:child ratios.</strong></p>
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="changedName-hint">
@@ -163,17 +163,17 @@
           <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Other requirements to count in the level 3 staff to child ratios
+              Other requirements to count in the level 3 staff:child ratios
             </span>
           </summary>
           <div class="govuk-details__text">
-            For someone who holds this qualification to be included in the staff to child ratios at level 3, they must:</p>
+            For someone who holds this qualification to be included in the staff:child ratios at level 3, they must:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>hold a suitable level 2 English qualification, as specified in the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
               <li>obtain a paediatric first aid qualification which meets the criteria in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years foundation stage (EYFS) statutory framework</a></li> within 3 months of starting work. To continue to be included in the ratio requirement the certificate must be renewed every 3 years.
               <li>meet all other requirements as set out in the  <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">EYFS</a> and the <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank">early years qualification requirements and standards document</a></li>
             </ul>
-            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff to child ratios at level 2.
+            <p class="govuk-body-m">A person who holds a full and relevant level 3 qualification started after September 2014, but who does not hold a suitable level 2 qualification in English can be counted in the staff:child ratios at level 2.
               </p>
             <p>Providers must make sure that their members of staff meet all other requirements as set out in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">EYFS</a> and the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards">early years qualification requirements and standards document</a>.</p>
           </div>
@@ -200,7 +200,7 @@
             <!-- <details class="govuk-details">
             <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">
-                Other requirements to count in the level 2 staff to child ratios
+                Other requirements to count in the level 2 staff:child ratios
               </span>
             </summary>
             <div class="govuk-details__text">
@@ -268,13 +268,13 @@
 </span>
 </summary>
 <div class="govuk-details__text">
-To be included in the staff to child ratios at level 6, staff must hold one of the following:</p>
+To be included in the staff:child ratios at level 6, staff must hold one of the following:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>Qualified Teacher Status (QTS)</li>
   <li>Early Years Teacher Status (EYTS)</li>
   <li>Early Years Professional Status (EYPS)</li>
 </ul>
-<p>Staff who hold one of these qualifications may be counted in the staff to child ratios at either level 3 or level 6, but not both.</p>
+<p>Staff who hold one of these qualifications may be counted in the staff:child ratios at either level 3 or level 6, but not both.</p>
 
 </div>
 </details> -->

--- a/app/views/current/r10/not-on-list.html
+++ b/app/views/current/r10/not-on-list.html
@@ -96,19 +96,19 @@
       </h2>
 
       <p>
-        The <a href="">EYFS statutory framework</a> sets out the requirements for staff to child ratios in settings delivering the EYFS and the qualification levels practitioners must hold to be included within those requirements.
+        The <a href="">EYFS statutory framework</a> sets out the requirements for staff:child ratios in settings delivering the EYFS and the qualification levels practitioners must hold to be included within those requirements.
       </p>
       <p>
-        The <a href="#">Early years qualification requirements and standards document</a> defines the qualifications that practitioners must hold to be included in the specified staff to child ratios at levels 2, 3 and 6 of the EYFS.
+        The <a href="#">Early years qualification requirements and standards document</a> defines the qualifications that practitioners must hold to be included in the specified staff:child ratios at levels 2, 3 and 6 of the EYFS.
       </p>
       <p>
-        To be included in the staff to child ratios at level 2, level 3 or level 6, staff must hold a qualification that is recognised by the Department for Education as full and relevant at the appropriate level. Any individual that does not hold a full and relevant qualification can only work as an unqualified member of staff in an early years setting and therefore cannot count in the staff to child ratios.
+        To be included in the staff:child ratios at level 2, level 3 or level 6, staff must hold a qualification that is recognised by the Department for Education as full and relevant at the appropriate level. Any individual that does not hold a full and relevant qualification can only work as an unqualified member of staff in an early years setting and therefore cannot count in the staff:child ratios.
       </p>
       <p>
-        Providers must refer to the EYFS statutory framework for any additional requirements that staff must meet to be included in the staff to child ratios (for example, Paediatric First Aid training).
+        Providers must refer to the EYFS statutory framework for any additional requirements that staff must meet to be included in the staff:child ratios (for example, Paediatric First Aid training).
       </p>
       <p>
-        You can read more about the level 2, 3 and 6 staff to child ratios, and the criteria for qualifications to be added to the EYQL in the <a href="#">Early years qualification requirements and standards document</a>.
+        You can read more about the level 2, 3 and 6 staff:child ratios, and the criteria for qualifications to be added to the EYQL in the <a href="#">Early years qualification requirements and standards document</a>.
 
       <h2 class="govuk-heading-m">
         Get more help and advice

--- a/app/views/current/r10/q1outsideuk.html
+++ b/app/views/current/r10/q1outsideuk.html
@@ -20,7 +20,7 @@
 
     <p class="govuk-body">If you did not get your qualification in the United Kingdom you will have to make an application for recognition to work in early years education in England.</p>
 
-    <p class="govuk-body">The early years qualifications achieved outside the United Kingdom guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the EYFS staff to child ratios in England.</p>
+    <p class="govuk-body">The early years qualifications achieved outside the United Kingdom guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the EYFS staff:child ratios in England.</p>
 
     <p class="govuk-body">This applies to those in:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/current/r10/q1scotwalirl.html
+++ b/app/views/current/r10/q1scotwalirl.html
@@ -20,7 +20,7 @@
 
     <!-- <p class="govuk-body">If you did not get your qualification in the United Kingdom you will have to make an application for recognition to work in early years education in England.</p>
     <br>
-    <p class="govuk-body">The early years qualifications achieved outside the United Kingdom guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the EYFS staff to child ratios in England.</p>
+    <p class="govuk-body">The early years qualifications achieved outside the United Kingdom guidance covers the information you will need to apply for recognition of overseas qualifications to be counted in the EYFS staff:child ratios in England.</p>
     <br>
     <p class="govuk-body">This applies to those in:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/current/r10/start.html
+++ b/app/views/current/r10/start.html
@@ -37,7 +37,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>check if an early years qualification is approved by the Department for Education (DfE) as full and relevant</li>
-        <li>confirm if someone who holds this qualification can count in staff to child ratios at level 2, 3 or 6</li>
+        <li>confirm if someone who holds this qualification can count in staff:child ratios at level 2, 3 or 6</li>
       </ul>
 
       <h2 class="govuk-heading-m">Before you start</h2>


### PR DESCRIPTION
After a conversation with Ellie and Dan, it's been decided to update 'staff to child ratios' to 'staff:child ratios' to keep consistency, so the content in the prototype has been updated accordingly