### PR TITLE
Remove the last sentence in the warning text in Check the additional …

### DIFF
--- a/app/views/current/r10/eyq-223.html
+++ b/app/views/current/r10/eyq-223.html
@@ -150,7 +150,7 @@
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-visually-hidden">Warning</span>
-          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+          Your result is dependent on the accuracy of the answers you have provided. 
         </strong>
       </div>
 

--- a/app/views/current/r10/eyq-224.html
+++ b/app/views/current/r10/eyq-224.html
@@ -146,7 +146,7 @@
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-visually-hidden">Warning</span>
-          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+          Your result is dependent on the accuracy of the answers you have provided.
         </strong>
       </div>
 

--- a/app/views/current/r10/eyq-293.html
+++ b/app/views/current/r10/eyq-293.html
@@ -160,7 +160,7 @@
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-visually-hidden">Warning</span>
-          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+          Your result is dependent on the accuracy of the answers you have provided.
         </strong>
       </div>
 

--- a/app/views/current/r10/eyq-300.html
+++ b/app/views/current/r10/eyq-300.html
@@ -172,7 +172,7 @@
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
           <span class="govuk-visually-hidden">Warning</span>
-          Your result is dependent on the accuracy of the answers you have provided. You must ensure all checks are carried out thoroughly.
+          Your result is dependent on the accuracy of the answers you have provided.
         </strong>
       </div>
 


### PR DESCRIPTION
- Take out 'You must ensure all checks are carried out thoroughly.’ sentence out the warning text in 'Check your additional requirements' page to match what’s on 'Your results' page