### PR TITLE
Fix date checked format

### DIFF
--- a/app/views/current/r10/_routes.js
+++ b/app/views/current/r10/_routes.js
@@ -78,7 +78,7 @@ router.post('/post-search-results', function(request, response) {
   
   const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
   var date = new Date(Date.now());
-  var dateString = date.getDate() + nth(date.getDate()) + " " + months[date.getMonth()] + " " + date.getFullYear();
+  var dateString = date.getDate() + " " + months[date.getMonth()] + " " + date.getFullYear();
   request.session.data['todays-date'] = dateString;
 
   response.redirect("/current/r10/search-results");


### PR DESCRIPTION
The 'Date checked' format on Your result' page was different (e.g. 7th June 2024) to the 'Date added to early years qualifications list' (e.g. 1 September 2014). I removed that bit in routes so that the format is the same for both