### PR TITLE
Remove date from the Confirm qualification page

### DIFF
--- a/app/views/current/r11/eyq-293-confirm-error.html
+++ b/app/views/current/r11/eyq-293-confirm-error.html
@@ -70,18 +70,6 @@
 
             }
           }
-          ,
-          {
-            key: {
-              text: "Date added to early years qualifications list"
-            },
-            value: {
-              text: "1 September 2014"
-            },
-            actions: {
-
-            }
-          }
         ]
       }) }}
 

--- a/app/views/current/r11/eyq-293-confirm.html
+++ b/app/views/current/r11/eyq-293-confirm.html
@@ -57,18 +57,6 @@
 
             }
           }
-          ,
-          {
-            key: {
-              text: "Date added to early years qualifications list"
-            },
-            value: {
-              text: "1 September 2014"
-            },
-            actions: {
-
-            }
-          }
         ]
       }) }}
 

--- a/app/views/current/r11/eyq-75-confirm-error.html
+++ b/app/views/current/r11/eyq-75-confirm-error.html
@@ -72,18 +72,6 @@
 
             }
           }
-          ,
-          {
-            key: {
-              text: "Date added to early years qualifications list"
-            },
-            value: {
-              text: "Before 1 September 2014"
-            },
-            actions: {
-
-            }
-          }
         ]
       }) }}
 

--- a/app/views/current/r11/eyq-75-confirm.html
+++ b/app/views/current/r11/eyq-75-confirm.html
@@ -59,18 +59,6 @@
 
             }
           }
-          ,
-          {
-            key: {
-              text: "Date added to early years qualifications list"
-            },
-            value: {
-              text: "Before 1 September 2014"
-            },
-            actions: {
-
-            }
-          }
         ]
       }) }}
 


### PR DESCRIPTION
Removed 'Date added to early years qualifications list' row from the table on the 'Confirm qualification' page