### PR TITLE
Feature/redesign select qualification page

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -16,3 +16,37 @@
     cursor: pointer;
     margin: 0;
 }
+
+.qualification-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.qualification-item {
+    position: relative;
+    padding: 10px 0;
+}
+
+.qualification-item a {
+    text-decoration: none;
+    color: #1d70b8;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.qualification-item a::after {
+    content: '\203A'; /* Unicode for right-pointing chevron */
+    font-size: 32px;
+    margin-left: 40px;
+    text-decoration: none;
+}
+
+.qualification-item hr {
+    border: 0;
+    height: 1px;
+    background: #d8d8d8;
+    margin: 10px 0 0;
+}
+

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -24,11 +24,23 @@ href: "/current/r11/q4"
     </h1>
 
     <ul class="govuk-list govuk-list--bullet">
-      {% if data['qualification-level'] != 'not-sure' %} <li>{{ 'Degree with honours' if data['qualification-level'] == 'degree-with-honours' else 'Level ' + data['qualification-level'] }}</li> {% endif %}
-      <li>{{ 'Any organisation' if data['awarding-organisation'] == 'any' else data['awarding-organisation']}}</li>
-      {% if data['awarding-date'] == 'before' %}<li>Before September 2014</li> {% endif %}
-      {% if data['awarding-date'] == 'after' %}<li>On or after 1 September 2014</li> {% endif %}
-      {% if data['awarding-date'] == '2024' %}<li>On or after 1 September 2024</li> {% endif %}
+
+      <li>{{data['awarding-location']}}</li> 
+
+      <li>{{data['date-started-month']}} {{data['date-started-year']}}</li>
+
+      {% if data['qualification-level'] == 'not-sure' %}
+        <li>Any level</li>
+      {% else %}
+        <li>data['qualification-level']</li>
+      {% endif %}
+
+      {% if data['awarding-organisation'] == 'any' %}
+        <li>Any organisation</li>
+      {% else %}
+        <li>data['awarding-organisation']</li>
+      {% endif %}
+      
     </ul>
 
     <p class="govuk-body">

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -111,18 +111,18 @@ href: "/current/r11/q4"
           })}}
       </div>
 
-      <ul class="govuk-list govuk-list--spaced">
+      <ul class="qualification-list">
         {% for qualification in data['search-results'] %}
-        <li>
-          <div>
-            <p class="govuk-body-l">
-              <strong>
-                <a href={{qualification.href}}>{{qualification.name}}</a>
-              </strong>
+          <li class="qualification-item">
+            <p class="govuk-body-m">
+              <a href={{qualification.href}}>
+                <strong style="text-decoration: underline; text-decoration-color: #1d70b8; text-decoration-thickness: 2px;">
+                  {{qualification.name}}
+                </strong>
+              </a>
             </p>
-          </div>
-          <hr />
-        </li>
+            <hr>
+          </li>
         {% endfor %}
       </ul>
 

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -71,7 +71,7 @@ href: "/current/r11/q4"
       <div class="govuk-form-group">
         <input class="govuk-input govuk-!-width-three-quarters" id="" name="qualification-search" type="text" value="{{data['qualification-search']}}">
         {{govukButton({
-          text: "Search",
+          text: "Refine",
           type: "Submit",
           classes: "govuk-button--secondary"
           })}}

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -64,13 +64,13 @@ href: "/current/r11/q4"
         <li>December {{data['date-started-year']}}</li>
       {% endif %}
 
-      {% if data['qualification-level'] == 'not-sure' %}
+      {% if data['qualification-level'] === 'not-sure' %}
         <li>Any level</li>
       {% else %}
         <li>Level {{data['qualification-level']}}</li>
       {% endif %}
 
-      {% if data['awarding-organisation'] == 'any' %}
+      {% if data['awarding-organisation'] === 'any' %}
         <li>Any organisation</li>
       {% else %}
         <li>{{data['awarding-organisation']}}</li>
@@ -95,7 +95,7 @@ href: "/current/r11/q4"
       <h1 class="govuk-heading-xl">Select the qualification</h1>
 
       <p class="govuk-body-l"><strong>{{ data['result-count'] }} {{ ' qualifications found' if data['result-count']
-          > 1 else ' qualification' }} </strong></p>
+          > 1 else ' qualification found' }} </strong></p>
 
       <div class="govuk-form-group">
         <label style="margin-bottom:-20px;" class="govuk-label" for="search">

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -91,6 +91,12 @@ href: "/current/r11/q4"
         </li>
         {% endfor %}
       </ul>
+
+      <p style="margin-top: 40px" class="govuk-body">
+        <a href="not-on-list" class="govuk-link">
+          I can not find the qualification on the list
+        </a>
+      </p>
     </form>
   </div>
 </div>

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -27,18 +27,20 @@ href: "/current/r11/q4"
 
       <li>{{data['awarding-location']}}</li> 
 
-      <li>{{data['date-started-month']}} {{data['date-started-year']}}</li>
+      <li>
+        {{data['date-started-month']}} {{data['date-started-year']}}
+      </li>
 
       {% if data['qualification-level'] == 'not-sure' %}
         <li>Any level</li>
       {% else %}
-        <li>data['qualification-level']</li>
+        <li>Level {{data['qualification-level']}}</li>
       {% endif %}
 
       {% if data['awarding-organisation'] == 'any' %}
         <li>Any organisation</li>
       {% else %}
-        <li>data['awarding-organisation']</li>
+        <li>{{data['awarding-organisation']}}</li>
       {% endif %}
 
     </ul>

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -60,7 +60,7 @@ href: "/current/r11/q4"
 
       <h1 class="govuk-heading-xl">Select the qualification</h1>
 
-      <p class="govuk-body-l"><strong>{{ data['result-count'] }} {{ ' qualifications' if data['result-count']
+      <p class="govuk-body-l"><strong>{{ data['result-count'] }} {{ ' qualifications found' if data['result-count']
           > 1 else ' qualification' }} </strong></p>
 
       <div class="govuk-form-group">

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -40,7 +40,7 @@ href: "/current/r11/q4"
       {% else %}
         <li>data['awarding-organisation']</li>
       {% endif %}
-      
+
     </ul>
 
     <p class="govuk-body">
@@ -62,14 +62,6 @@ href: "/current/r11/q4"
 
       <p class="govuk-body-l"><strong>{{ data['result-count'] }} {{ ' qualifications' if data['result-count']
           > 1 else ' qualification' }} </strong></p>
-
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-          <span class="govuk-visually-hidden">Warning</span>
-          To be full and relevant, the qualification name must exactly match the qualification on the certificate, including any wording in brackets.
-          </strong>
-      </div>
 
       <div class="govuk-form-group">
         <label style="margin-bottom:-20px;" class="govuk-label" for="search">

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -27,9 +27,42 @@ href: "/current/r11/q4"
 
       <li>{{data['awarding-location']}}</li> 
 
-      <li>
-        {{data['date-started-month']}} {{data['date-started-year']}}
-      </li>
+      {% if data['date-started-month'] === '1' or data['date-started-month'] === '01' %}
+        <li>January {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '2' or data['date-started-month'] === '02'%}
+        <li>February {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '3'or data['date-started-month'] === '03' %}
+        <li>March {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '4' or data['date-started-month'] === '04' %}
+        <li>April {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '5' or data['date-started-month'] === '05'%}
+        <li>May {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '6' or data['date-started-month'] === '06'%}
+        <li>June {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '7' or data['date-started-month'] === '07'%}
+        <li>July {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '8' or data['date-started-month'] === '08'%}
+        <li>August {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '9' or data['date-started-month'] === '09' %}
+        <li>September {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '10' %}
+        <li>October {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '11' %}
+        <li>November {{data['date-started-year']}}</li>
+      {% endif %}
+      {% if data['date-started-month'] === '12' %}
+        <li>December {{data['date-started-year']}}</li>
+      {% endif %}
 
       {% if data['qualification-level'] == 'not-sure' %}
         <li>Any level</li>
@@ -42,7 +75,6 @@ href: "/current/r11/q4"
       {% else %}
         <li>{{data['awarding-organisation']}}</li>
       {% endif %}
-
     </ul>
 
     <p class="govuk-body">

--- a/app/views/current/r11/search-results.html
+++ b/app/views/current/r11/search-results.html
@@ -81,12 +81,11 @@ href: "/current/r11/q4"
         {% for qualification in data['search-results'] %}
         <li>
           <div>
-            <h2><a href={{qualification.href}}>{{qualification.name}}</a></h2>
-
-            {% if qualification.additionalRequirementsNumber >0  %}<p>This qualification has {{qualification.additionalRequirementsNumber}} additional {{ ' requirements' if qualification.additionalRequirementsNumber
-              > 1 else ' requirement' }}.</p>{% endif %}
-            <p><strong>Level: </strong>{{ 'Degree with honours' if qualification.level == 'degree-with-honours' else qualification.level }}</p>
-            <p><strong>Awarding organisation:</strong> {{qualification.awardingOrganisation}}</p>
+            <p class="govuk-body-l">
+              <strong>
+                <a href={{qualification.href}}>{{qualification.name}}</a>
+              </strong>
+            </p>
           </div>
           <hr />
         </li>


### PR DESCRIPTION
- Added location in your search and reordered the other bullet points
- Changed ‘x qualifications’ to ‘x qualifications found’
- Removed warning text
- Renamed the search box as 'Refine'
- Displayed month name instead of month number
- Added a chevron > next to the qualification name
- Removed the details under the qualification
- Added a link at the bottom to take users to a static Not on the list page
