### PR TITLE
Updated routing in where was the qualification awarded

### DIFF
--- a/app/views/current/r11/_routes.js
+++ b/app/views/current/r11/_routes.js
@@ -7,9 +7,10 @@ var data = require('../../../data/qualifications.json');
 router.post('/q1-post', function(request, response){
   if (request.session.data['awarding-location'] == undefined) {
     response.redirect("/current/r11/q1-error")
-  } else {
+  } 
+  if (request.session.data['awarding-location'] == 'England') {
     response.redirect("/current/r11/q2")
-  }
+  } 
 })
 
 router.post('/q2-post', function(request, response){


### PR DESCRIPTION
Updated routing in where was the qualification awarded:
- if users don't select any option, an error will pop up
- if users select 'England', they will be sent to the 'When was the qualification started' page
- if users select any of the other options, nothing will happen on the prototype because we're not testing those journeys. In real-life scenarios, users would be taken to specific static pages for each of the options