### PR TITLE
Feature/remove qualification holder references

### DIFF
--- a/app/views/current/r11/eyq-240-requirement1-error.html
+++ b/app/views/current/r11/eyq-240-requirement1-error.html
@@ -34,7 +34,7 @@
           Did the qualification include an element of assessed practice in an early years setting in England?
         </h1>
         <p class="govuk-hint">
-          If you do not know, you can ask the qualification holder, the awarding organisation or the training provider.
+          If you do not know, you can ask the awarding organisation or the training provider.
         </p>
 
         {{ govukRadios({

--- a/app/views/current/r11/eyq-240-requirement1.html
+++ b/app/views/current/r11/eyq-240-requirement1.html
@@ -21,7 +21,7 @@
         Did the qualification include an element of assessed practice in an early years setting in England?
       </h1>
       <p class="govuk-hint">
-        If you do not know, you can ask the qualification holder, the awarding organisation or the training provider.
+        If you do not know, you can ask the awarding organisation or the training provider.
       </p>
 
       {{ govukRadios({

--- a/app/views/current/r11/eyq-293-requirement1-error.html
+++ b/app/views/current/r11/eyq-293-requirement1-error.html
@@ -34,7 +34,7 @@
           Did the qualification include an element of assessed practice in an early years setting?
         </h1>
         <p class="govuk-hint">
-          If you do not know, you can ask the qualification holder, the awarding organisation or the training provider.
+          If you do not know, you can ask the awarding organisation or the training provider.
         </p>
 
         {{ govukRadios({

--- a/app/views/current/r11/eyq-293-requirement1.html
+++ b/app/views/current/r11/eyq-293-requirement1.html
@@ -21,7 +21,7 @@
         Did the qualification include an element of assessed practice in an early years setting?
       </h1>
       <p class="govuk-hint">
-        If you do not know, you can ask the qualification holder, the awarding organisation or the training provider.
+        If you do not know, you can ask the awarding organisation or the training provider.
       </p>
 
       {{ govukRadios({

--- a/app/views/current/r11/eyq-293-requirement2-error.html
+++ b/app/views/current/r11/eyq-293-requirement2-error.html
@@ -34,7 +34,7 @@
           Was the course fully consistent with the QAA Subject Benchmark Statement for Early Childhood Studies?
         </h1>
         <p class="govuk-hint">
-          If you do not know, you can ask the qualification holder, the awarding organisation or the training provider.
+          If you do not know, you can ask the awarding organisation or the training provider.
         </p>
         <details class="govuk-details">
           <summary class="govuk-details__summary">

--- a/app/views/current/r11/eyq-293-requirement2.html
+++ b/app/views/current/r11/eyq-293-requirement2.html
@@ -21,7 +21,7 @@
         Was the course fully consistent with the QAA Subject Benchmark Statement for Early Childhood Studies?
       </h1>
       <p class="govuk-hint">
-        If you do not know, you can ask the qualification holder, the awarding organisation or the training provider.
+        If you do not know, you can ask the awarding organisation or the training provider.
       </p>
       <details class="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/current/r11/q2-error.html
+++ b/app/views/current/r11/q2-error.html
@@ -36,9 +36,6 @@
             classes: "govuk-heading-xl govuk-!-margin-bottom-4"
           }
         }) %}
-        <p>
-          If you do not know the date the qualification was started, you can ask the qualification holder.
-        </p>
         <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">

--- a/app/views/current/r11/q2.html
+++ b/app/views/current/r11/q2.html
@@ -25,9 +25,6 @@
           classes: "govuk-heading-xl govuk-!-margin-bottom-4"
         }
       }) %}
-      <p>
-        If you do not know the date the qualification was started, you can ask the qualification holder.
-      </p>
       <details class="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">

--- a/app/views/current/r11/q3-error.html
+++ b/app/views/current/r11/q3-error.html
@@ -46,7 +46,6 @@
           <p>To find the level of a qualification, you can:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>check the qualification certificate</li>
-            <li>ask the person who holds the qualification</li>
             <li>check with the awarding organisation</li>
             <li>see <a href="https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" class="govuk-link" rel="noreferrer noopener" target="_blank">examples of qualification levels in England, Wales and Northern Ireland (opens in new tab)</a></li>
           </ul>

--- a/app/views/current/r11/q3.html
+++ b/app/views/current/r11/q3.html
@@ -29,7 +29,6 @@
         <p>To find the level of a qualification, you can:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>check the qualification certificate</li>
-          <li>ask the person who holds the qualification</li>
           <li>check with the awarding organisation</li>
           <li>see <a href="https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" class="govuk-link" rel="noreferrer noopener" target="_blank">examples of qualification levels in England, Wales and Northern Ireland (opens in new tab)</a></li>
         </ul>


### PR DESCRIPTION
Removed any references to the qualification holder from the following pages:
- When was the qualifications started
- What level is the qualification
- Requirements questions