### PR TITLE
Removed content from detail in level question

### DIFF
--- a/app/views/current/r11/q3-error.html
+++ b/app/views/current/r11/q3-error.html
@@ -42,7 +42,6 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          <p>Most qualifications have a difficulty level. The higher the level, the more difficult the qualification is.</p>
           <p>To find the level of a qualification, you can:</p>
           <ul class="govuk-list govuk-list--bullet">
             <li>check the qualification certificate</li>


### PR DESCRIPTION
Removed first sentence in the detail component in the q3-error page because it was a legacy from a previos version