### PR TITLE
Updated content and added missing heading

### DIFF
--- a/app/views/current/r12/not-on-list.html
+++ b/app/views/current/r12/not-on-list.html
@@ -36,29 +36,13 @@
       Some qualifications are awarded by multiple awarding organisations with the same qualification title. These qualifications may be listed under 'various awarding organisations'.
     </p>
   <h2 class="govuk-heading-l">
-    Qualifications listed with 'various awarding organisations'
+    Higher education qualifications
   </h2>
     <p>
       Many universities and other higher education institutions offer qualifications in Early Childhood Studies or related subjects. Due to the range of qualifications available at this level, DfE does not always individually list each qualification on the EYQL.
     </p>
   <h3 class="govuk-heading-m">
     Level 4 and 5 qualifications, including HND and foundation degrees
-  </h3>
-    <p>
-      Some level 4 and 5 qualifications started before September 2014 are grouped together, with several qualifications listed as a single entry on the EYQL. If the qualification you are checking was started before September 2014 and is a:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Certificate of Higher Education</li>
-      <li>Higher National Certificate (HNC)</li>
-      <li>Higher National Diploma (HND)</li>
-      <li>Diploma of Higher Education</li>
-      <li>Foundation Degree</li>
-    </ul>
-    <p>
-      You should return to the search results and choose the option which includes the qualification name that you are checking.
-    </p>
-  <h3 class="govuk-heading-m">
-     Level 4 and 5 qualifications, including HND and foundation degrees
   </h3>
     <p>
       Some level 4 and 5 qualifications started before September 2014 are grouped together, with several qualifications listed as a single entry on the EYQL. If the qualification you are checking was started before September 2014 and is a:
@@ -107,8 +91,10 @@
     <p class="govuk-body-m">
       This means that the qualification holder is not able to work as a qualified member of staff within the staff:child ratios in a registered early years setting in England. They can, however, work as an unqualified member of staff.
     </p>
-  <h2 class="govuk-heading-l">
 
+  <h2 class="govuk-heading-l">
+    Related content
+  </h2>
   <p class="govuk-body-m">
       <a href="https://www.gov.uk/guidance/early-years-qualifications-finder" target="_blank">Guidance on checking early years qualifications (opens in new tab)</a>
   </p>


### PR DESCRIPTION
- Updated the second ’Qualifications listed with ‘various awarding organisations’ heading to ‘Higher education qualifications’
- Deleted one ‘Level 4 and 5 qualifications, including HND and foundation degrees’ section
- Added the ‘Related content’ heading above the last 3 links