### PR TITLE
Link to open on the same tab

### DIFF
--- a/app/views/current/r12/not-on-list.html
+++ b/app/views/current/r12/not-on-list.html
@@ -55,7 +55,7 @@
       <li>Foundation Degree</li>
     </ul>
     <p>
-      You should return to <a href="/current/r12/search-results" target="_blank">select the qualification</a> and choose the option which includes the qualification name that you are checking.
+      You should return to <a href="/current/r12/search-results">select the qualification</a> and choose the option which includes the qualification name that you are checking.
     </p>
   <h3 class="govuk-heading-m">
     Level 6 qualifications, including BA (Hons) degrees


### PR DESCRIPTION
Remove blank target for the 'select the qualification' link on the 'I cannot find the qualification' page