### PR TITLE
Fixed wording issues in requirements

### DIFF
--- a/app/views/current/r16/eyq-236-checked.html
+++ b/app/views/current/r16/eyq-236-checked.html
@@ -190,16 +190,16 @@
               Level 2 English qualification
             </h4>
             <p class="govuk-body-m">
-              As this qualification was achieved on or after 1 September 2014, the member of staff must also hold a suitable level 2 English qualification to be included in the staff:child ratios at level 3. You can find a list of suitable Level 2 English qualifications in the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards" target="_blank">early years qualification requirements and standards document (opens in new tab)</a>.
+              As this qualification was awarded on or after 1 September 2014, the member of staff must also hold a suitable level 2 English qualification to be included in the staff:child ratios at level 3. You can find a list of suitable Level 2 English qualifications in the <a href="https://www.gov.uk/government/publications/early-years-qualification-requirements-and-standards" target="_blank">early years qualification requirements and standards document (opens in new tab)</a>.
             </p>
             <p class="govuk-body-m">
-              A person who holds a full and relevant level 3 qualification achieved on or after 1 September 2014, but who does not hold a suitable level 2 English qualification can be counted in the staff:child ratios at level 2.
+              A person who holds a full and relevant level 3 qualification awarded on or after 1 September 2014, but who does not hold a suitable level 2 English qualification can be counted in the staff:child ratios at level 2.
             </p>
             <h4 class="govuk-heading-s">
               Paediatric first aid certificate
             <h4>
             <p class="govuk-body-m">
-              If this qualification was obtained since 30 June 2016, the member of staff must obtain a paediatric first aid certificate which meets the criteria in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" target="_blank">early years foundation stage (EYFS) statutory framework (opens in new tab)</a> within 3 months of starting work. To continue to be included in the ratio, the certificate must be renewed every 3 years.
+              If this qualification was awarded on or after 30 June 2016, the member of staff must obtain a paediatric first aid certificate which meets the criteria in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" target="_blank">early years foundation stage (EYFS) statutory framework (opens in new tab)</a> within 3 months of starting work. To continue to be included in the ratio, the certificate must be renewed every 3 years.
             </p>
           </div>
         </details>
@@ -232,7 +232,7 @@
               Paediatric first aid certificate
             <h4>
             <p class="govuk-body-m">
-              If this qualification was obtained since 30 June 2016, the member of staff must obtain a paediatric first aid certificate which meets the criteria in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" target="_blank">early years foundation stage (EYFS) statutory framework (opens in new tab)</a> within 3 months of starting work. To continue to be included in the ratio, the certificate must be renewed every 3 years.
+              If this qualification was awarded on or after 30 June 2016, the member of staff must obtain a paediatric first aid certificate which meets the criteria in the <a href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2" target="_blank">early years foundation stage (EYFS) statutory framework (opens in new tab)</a> within 3 months of starting work. To continue to be included in the ratio, the certificate must be renewed every 3 years.
             </p>
           </div>
         </details>


### PR DESCRIPTION
- Replaced 'obtained' and 'achieved' with 'awarded'
- Replaced 'since' with 'on or after'